### PR TITLE
Fix asmdef autoReferenced setting

### DIFF
--- a/src/DryDB.Unity/Assets/DryDB/Runtime/DryDB.Unity.asmdef
+++ b/src/DryDB.Unity/Assets/DryDB/Runtime/DryDB.Unity.asmdef
@@ -9,7 +9,7 @@
     "precompiledReferences": [
         "DryDB.dll"
     ],
-    "autoReferenced": false,
+    "autoReferenced": true,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false


### PR DESCRIPTION
VContainer and VitalRouter have autoReferenced set to true in their asmdef files, so I aligned this setting as well.