### PR TITLE
Fix page refcount leak in RangeIterator.TrySeek

### DIFF
--- a/src/DryDB/RangeIterator.cs
+++ b/src/DryDB/RangeIterator.cs
@@ -137,6 +137,11 @@ public class RangeIterator :
             currentPage?.Release();
             currentPage = page;
         }
+        else
+        {
+            // TrySearch acquired another reference to the page we already hold
+            page.Release();
+        }
         currentEntryIndex = entryIndex;
         return true;
     }
@@ -168,6 +173,11 @@ public class RangeIterator :
         {
             currentPage?.Release();
             currentPage = page;
+        }
+        else
+        {
+            // TrySearch acquired another reference to the page we already hold
+            page.Release();
         }
         currentEntryIndex = entryIndex;
         return true;

--- a/tests/DryDB.Tests/RangeIteratorTest.cs
+++ b/tests/DryDB.Tests/RangeIteratorTest.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using DryDB.Internal;
@@ -7,6 +8,42 @@ namespace DryDB.Tests;
 [TestFixture]
 public class RangeIteratorTest
 {
+    [Test]
+    public async Task Seek_SameKeyTwice_DoesNotLeakPageReference()
+    {
+        var tree = await TestHelper.BuildTreeAsync(
+            new UniqueKeyValueList(KeyEncoding.Ascii)
+            {
+                { "key1"u8.ToArray(), "value1"u8.ToArray() },
+                { "key2"u8.ToArray(), "value2"u8.ToArray() },
+                { "key3"u8.ToArray(), "value3"u8.ToArray() },
+                { "key5"u8.ToArray(), "value5"u8.ToArray() },
+                { "key7"u8.ToArray(), "value7"u8.ToArray() },
+                { "key8"u8.ToArray(), "value8"u8.ToArray() },
+                { "key9"u8.ToArray(), "value9"u8.ToArray() },
+            }, 128);
+
+        var iterator = tree.CreateIterator();
+        Assert.That(iterator.TrySeek("key5"u8), Is.True);
+        Assert.That(iterator.TrySeek("key5"u8), Is.True);
+        Assert.That(await iterator.TrySeekAsync("key5"u8.ToArray()), Is.True);
+
+        // one reference held by the page cache + one held by the iterator
+        Assert.That(GetCurrentPageRefCount(iterator), Is.EqualTo(2));
+
+        Assert.That(
+            Encoding.ASCII.GetString(iterator.Current.Span),
+            Is.EqualTo("value5"));
+    }
+
+    static int GetCurrentPageRefCount(RangeIterator iterator)
+    {
+        var currentPage = typeof(RangeIterator)
+            .GetField("currentPage", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(iterator)!;
+        return (int)currentPage.GetType().GetField("RefCount")!.GetValue(currentPage)!;
+    }
+
     [Test]
     public async Task MoveNext_FirstValue()
     {


### PR DESCRIPTION
## Problem

`RangeIterator.TrySeek` / `TrySeekAsync` call `TreeWalker.TrySearch`, which returns the found leaf page with a newly retained reference. When seeking to a key on the page the iterator already holds (`currentPage == page`), that new reference was neither stored nor released, so the page's refcount grew by one on every such seek. A leaked refcount prevents the page buffer from ever being disposed after cache eviction.

## Fix

Release the duplicate reference when the seek lands on the page the iterator already holds.

## Test

Added a regression test that seeks the same key repeatedly and asserts the refcount stays balanced (1 held by the page cache + 1 by the iterator). It fails with refcount=4 before this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)