### PR TITLE
Fix page over-release in CountRange

### DIFF
--- a/src/DryDB/BTree/TreeWalker.cs
+++ b/src/DryDB/BTree/TreeWalker.cs
@@ -509,10 +509,7 @@ class TreeWalker
             {
                 if (!nextPageNumber.HasValue) return 0;
 
-                while (!PageCache.TryGet(nextPageNumber.Value, out page))
-                {
-                    PageCache.Load(nextPageNumber.Value);
-                }
+                PageCache.Load(nextPageNumber.Value);
             }
         }
 
@@ -520,9 +517,13 @@ class TreeWalker
 
         while (true)
         {
+            // `page` is reassigned to the right sibling inside the loop; keep the
+            // reference we own so that the finally releases the page we walked,
+            // not the newly acquired one.
+            var currentPage = page;
             try
             {
-                var pageSpan = page.Memory.Span;
+                var pageSpan = currentPage.Memory.Span;
                 var header = NodeHeader.Parse(pageSpan);
                 if (header.Kind != NodeKind.Leaf)
                 {
@@ -570,7 +571,7 @@ class TreeWalker
             }
             finally
             {
-                page.Release();
+                currentPage.Release();
             }
         }
     }
@@ -611,10 +612,7 @@ class TreeWalker
             {
                 if (!nextPageNumber.HasValue) return 0;
 
-                while (!PageCache.TryGet(nextPageNumber.Value, out page))
-                {
-                    await PageCache.LoadAsync(nextPageNumber.Value, cancellationToken).ConfigureAwait(false);
-                }
+                await PageCache.LoadAsync(nextPageNumber.Value, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -622,9 +620,13 @@ class TreeWalker
 
         while (true)
         {
+            // `page` is reassigned to the right sibling inside the loop; keep the
+            // reference we own so that the finally releases the page we walked,
+            // not the newly acquired one.
+            var currentPage = page;
             try
             {
-                var pageSpan = page.Memory.Span;
+                var pageSpan = currentPage.Memory.Span;
                 var header = NodeHeader.Parse(pageSpan);
                 if (header.Kind != NodeKind.Leaf)
                 {
@@ -672,7 +674,7 @@ class TreeWalker
             }
             finally
             {
-                page.Release();
+                currentPage.Release();
             }
         }
     }

--- a/tests/DryDB.Tests/ReadOnlyTableTest.cs
+++ b/tests/DryDB.Tests/ReadOnlyTableTest.cs
@@ -259,6 +259,40 @@ public class ReadOnlyTableTest
     }
 
     [Test]
+    public async Task CountRange_Repeated_DoesNotCorruptPageCache()
+    {
+        var table = await TestHelper.BuildTableAsync(
+            KeyEncoding.Ascii,
+            databaseConfigure: builder => builder.PageSize = 128,
+            tableConfigure: builder =>
+            {
+                for (var i = 0; i < 1000; i++)
+                {
+                    builder.Append(
+                        Encoding.ASCII.GetBytes($"key{i:D5}"),
+                        Encoding.ASCII.GetBytes($"value{i:D5}"));
+                }
+            });
+
+        // CountRange used to release the pages it walked one too many times, killing
+        // the cache entry for the last page of the range. Any later traversal through
+        // that page then spun forever in the TryGet/Load retry loop.
+        var completed = Task.Run(() =>
+        {
+            for (var i = 0; i < 3; i++)
+            {
+                var count = table.CountRange("key00100"u8, "key00900"u8);
+                Assert.That(count, Is.EqualTo(801));
+            }
+
+            using var result = table.Get("key00900"u8);
+            Assert.That(result.HasValue, Is.True);
+        }).Wait(TimeSpan.FromSeconds(10));
+
+        Assert.That(completed, Is.True, "CountRange corrupted the page cache (deadlock)");
+    }
+
+    [Test]
     public async Task GetRangeWithPrefix_Basic()
     {
         var table = await TestHelper.BuildTableAsync(


### PR DESCRIPTION
## Problem

In `TreeWalker.CountRange` / `CountRangeAsync`, the sibling-walk loop reassigns `page` to the newly acquired right sibling **inside** the `try` block, while the `finally` releases `page`. So each iteration releases the page it just acquired instead of the page it just finished counting:

- the start page's reference is never released (refcount leak)
- every subsequent page gets double-released; when the loop returns, the last page's refcount hits 0 and its buffer is returned to the pool **while the entry is still in the page cache map**

Any later traversal that touches that dead entry spins forever: `TryGet` keeps failing (refcount is 0) and `Load` keeps no-op'ing (the dead entry still occupies the map slot). Since the buffer went back to `MemoryPool` while still reachable, data corruption is also possible.

A single `CountRange` call succeeds — the dead entry is only observed by the *next* traversal — which is why existing tests never caught it. It surfaced as an infinite loop when running `CountRange` in a benchmark loop.

The start-position retry loop also leaked one reference per cache miss (`TryGet` into `page`, which the subsequent `TrySearch` retry overwrites).

## Fix

Snapshot the owned reference per iteration (`var currentPage = page`) and release that, matching the existing pattern in `GetRangeAscending`. The retry loop now just calls `Load`, also matching `GetRangeAscending`.

## Test

Added a regression test that runs `CountRange` repeatedly over a multi-page range and then reads a key on the range's last page, guarded by a 10s timeout. Before the fix it deadlocks; after the fix the whole suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)