### PR TITLE
Optimize read hot path and expand benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
 
 DryDB is a read-only embedded B+Tree based key/value database, implemented pure C#.
 
-```
-| Method             | Mean        | Error     | StdDev    |
-|------------------- |------------:|----------:|----------:|
-| DryDB_FindByKey    |    37.57 us |  0.230 us |  0.120 us |
-| CsSqlite_FindByKey | 4,322.48 us | 44.492 us | 26.476 us |
-```
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/benchmarks/point_lookup_dark.svg">
+  <img alt="Point lookup benchmark: DryDB 29 ns, RocksDB 241 ns, SQLite (prepared + immutable) 943 ns, SQLite (default) 6,656 ns per query" src="docs/benchmarks/point_lookup_light.svg">
+</picture>
+
+See [Performance](#performance) for details.
 
 ## Features
 
@@ -43,6 +43,64 @@ DryDB is a read-only embedded B+Tree based key/value database, implemented pure 
   - By manipulating the cursor, large areas can be accessed sequentially.
 - CLI tool
 - Support for large BLOBs. (Values exceeding 65,536 bytes are stored on a separated page.)
+
+## Performance
+
+All benchmarks read a table of 10,000 rows (int64 primary key, 13-byte value) with 4 KB pages, on Apple M-series / .NET 10, measured with BenchmarkDotNet. Lower is better.
+
+Two SQLite configurations are shown to keep the comparison fair:
+
+- **default** — a command is created and parsed for every query (typical naive usage)
+- **prepared + immutable** — the statement is prepared once and reused, and the file is opened with [`immutable=1`](https://www.sqlite.org/uri.html#uriimmutable), the fastest read-only setup SQLite offers
+
+### Point lookup
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/benchmarks/point_lookup_dark.svg">
+  <img alt="Point lookup benchmark: DryDB 29 ns, RocksDB 241 ns, SQLite (prepared + immutable) 943 ns, SQLite (default) 6,656 ns per query" src="docs/benchmarks/point_lookup_light.svg">
+</picture>
+
+### Range scan
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/benchmarks/range_scan_dark.svg">
+  <img alt="Range scan benchmark (100 rows): DryDB 1.4 µs, SQLite (prepared + immutable) 9.6 µs, RocksDB 14.0 µs, SQLite (default) 17.4 µs per query" src="docs/benchmarks/range_scan_light.svg">
+</picture>
+
+### Count by key range
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/benchmarks/count_range_dark.svg">
+  <img alt="Count benchmark (8,000 rows): DryDB 15.2 µs, SQLite (default) 108 µs, SQLite (prepared + immutable) 117 µs, RocksDB 982 µs per query" src="docs/benchmarks/count_range_light.svg">
+</picture>
+
+<details>
+<summary>Raw BenchmarkDotNet results</summary>
+
+1 op = 1000 queries for point lookup, 100 queries for range scan and count.
+
+| Type           | Method                   | Mean         | Error        | StdDev       | Allocated  |
+|--------------- |------------------------- |-------------:|-------------:|-------------:|-----------:|
+| ReadBenchmark  | DryDB_FindByKey          |     29.00 us |     2.133 us |     1.269 us |          - |
+| ReadBenchmark  | RocksDB_FindByKey        |    240.74 us |    42.123 us |    27.862 us |    40032 B |
+| ReadBenchmark  | CsSqlite_FindByKey_Fair  |    943.04 us |   152.115 us |   100.615 us |    48000 B |
+| ReadBenchmark  | CsSqlite_FindByKey       |  6,655.59 us |   557.215 us |   368.563 us |    48000 B |
+| RangeBenchmark | DryDB_GetRange           |    140.02 us |     6.377 us |     4.218 us |          - |
+| RangeBenchmark | CsSqlite_GetRange_Fair   |    958.48 us |   124.718 us |    82.493 us |   480000 B |
+| RangeBenchmark | RocksDB_GetRange         |  1,396.66 us |   157.288 us |   104.036 us |   726432 B |
+| RangeBenchmark | CsSqlite_GetRange        |  1,743.15 us |   218.851 us |   144.757 us |   480000 B |
+| CountBenchmark | DryDB_CountRange         |  1,524.56 us |   123.628 us |    81.772 us |          - |
+| CountBenchmark | CsSqlite_CountRange      | 10,796.05 us |   956.138 us |   632.426 us |          - |
+| CountBenchmark | CsSqlite_CountRange_Fair | 11,715.51 us |   926.636 us |   551.426 us |          - |
+| CountBenchmark | RocksDB_CountRange       | 98,221.60 us | 5,595.564 us | 3,701.119 us | 25606432 B |
+
+</details>
+
+> [!NOTE]
+> DryDB returns values as zero-copy slices of cached pages, so read paths allocate no managed memory.
+> The RocksDB numbers go through the C# binding ([rocksdb-sharp](https://github.com/curiosity-ai/rocksdb-sharp)), whose iterator allocates a `byte[]` per key/value access — the count benchmark in particular is dominated by that binding overhead rather than the storage engine itself.
+
+The benchmark source is in [sandbox/DryDB.Benchmark](sandbox/DryDB.Benchmark).
 
 ## Why read-only ?
 

--- a/docs/benchmarks/count_range_dark.svg
+++ b/docs/benchmarks/count_range_dark.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 242" width="800" height="242" role="img" aria-label="Count by key range benchmark">
+  <rect x="0.5" y="0.5" width="799" height="241" rx="8" fill="#1a1a19" stroke="#33322f"/>
+  <g font-family="ui-sans-serif, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif">
+    <text x="24" y="30" font-size="15" font-weight="600" fill="#ffffff">Count by key range</text>
+    <text x="24" y="48" font-size="11.5" fill="#c3c2b7">Count 8,000 rows in a key range — time per query (lower is better)</text>
+    <line x1="262" y1="58" x2="262" y2="203" stroke="#3a3936" stroke-width="1"/>
+  <text x="250" y="75" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">DryDB</text>
+  <path d="M262 64 h3.25 a3.25050916496945 3.25050916496945 0 0 1 3.25050916496945 3.25050916496945 v15.498981670061099 a3.25050916496945 3.25050916496945 0 0 1 -3.25050916496945 3.25050916496945 h-3.25 Z" fill="#3987e5"/>
+  <text x="276.5010183299389" y="75" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">15.2 µs</text>
+  <text x="250" y="112" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">SQLite (CsSqlite, default)</text>
+  <path d="M262 101 h42.19 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-42.19 Z" fill="#8d8c82"/>
+  <text x="316.19144602851327" y="112" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">108 µs</text>
+  <text x="250" y="149" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">SQLite (CsSqlite, prepared + immutable)</text>
+  <path d="M262 138 h46.04 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-46.04 Z" fill="#8d8c82"/>
+  <text x="320.040733197556" y="149" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">117 µs</text>
+  <text x="250" y="186" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">RocksDB</text>
+  <path d="M262 175 h416.00 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-416 Z" fill="#8d8c82"/>
+  <text x="690" y="186" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">982 µs</text>
+    <text x="24" y="230" font-size="10.5" fill="#8a897f">BenchmarkDotNet · .NET 10 · Apple M-series · 10,000 rows (int64 key, 13-byte value) · 4 KB pages</text>
+  </g>
+</svg>

--- a/docs/benchmarks/count_range_dark.svg
+++ b/docs/benchmarks/count_range_dark.svg
@@ -5,16 +5,17 @@
     <text x="24" y="48" font-size="11.5" fill="#c3c2b7">Count 8,000 rows in a key range — time per query (lower is better)</text>
     <line x1="262" y1="58" x2="262" y2="203" stroke="#3a3936" stroke-width="1"/>
   <text x="250" y="75" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">DryDB</text>
-  <path d="M262 64 h3.25 a3.25050916496945 3.25050916496945 0 0 1 3.25050916496945 3.25050916496945 v15.498981670061099 a3.25050916496945 3.25050916496945 0 0 1 -3.25050916496945 3.25050916496945 h-3.25 Z" fill="#3987e5"/>
-  <text x="276.5010183299389" y="75" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">15.2 µs</text>
+  <path d="M262 64 h43.45 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-43.45 Z" fill="#3987e5"/>
+  <text x="317.44704570791527" y="75" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">15.2 µs</text>
   <text x="250" y="112" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">SQLite (CsSqlite, default)</text>
-  <path d="M262 101 h42.19 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-42.19 Z" fill="#8d8c82"/>
-  <text x="316.19144602851327" y="112" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">108 µs</text>
+  <path d="M262 101 h333.12 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-333.12 Z" fill="#8d8c82"/>
+  <text x="607.123745819398" y="112" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">108 µs</text>
   <text x="250" y="149" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">SQLite (CsSqlite, prepared + immutable)</text>
-  <path d="M262 138 h46.04 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-46.04 Z" fill="#8d8c82"/>
-  <text x="320.040733197556" y="149" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">117 µs</text>
+  <path d="M262 138 h361.22 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-361.22 Z" fill="#8d8c82"/>
+  <text x="635.2173913043479" y="149" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">117 µs</text>
   <text x="250" y="186" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">RocksDB</text>
   <path d="M262 175 h416.00 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-416 Z" fill="#8d8c82"/>
+  <path d="M606.4 173 l-6 26 h7 l6 -26 Z" fill="#1a1a19"/>
   <text x="690" y="186" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">982 µs</text>
     <text x="24" y="230" font-size="10.5" fill="#8a897f">BenchmarkDotNet · .NET 10 · Apple M-series · 10,000 rows (int64 key, 13-byte value) · 4 KB pages</text>
   </g>

--- a/docs/benchmarks/count_range_light.svg
+++ b/docs/benchmarks/count_range_light.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 242" width="800" height="242" role="img" aria-label="Count by key range benchmark">
+  <rect x="0.5" y="0.5" width="799" height="241" rx="8" fill="#fcfcfb" stroke="#e6e5e0"/>
+  <g font-family="ui-sans-serif, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif">
+    <text x="24" y="30" font-size="15" font-weight="600" fill="#0b0b0b">Count by key range</text>
+    <text x="24" y="48" font-size="11.5" fill="#52514e">Count 8,000 rows in a key range — time per query (lower is better)</text>
+    <line x1="262" y1="58" x2="262" y2="203" stroke="#d8d7d2" stroke-width="1"/>
+  <text x="250" y="75" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">DryDB</text>
+  <path d="M262 64 h3.25 a3.25050916496945 3.25050916496945 0 0 1 3.25050916496945 3.25050916496945 v15.498981670061099 a3.25050916496945 3.25050916496945 0 0 1 -3.25050916496945 3.25050916496945 h-3.25 Z" fill="#2a78d6"/>
+  <text x="276.5010183299389" y="75" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">15.2 µs</text>
+  <text x="250" y="112" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">SQLite (CsSqlite, default)</text>
+  <path d="M262 101 h42.19 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-42.19 Z" fill="#7c7b74"/>
+  <text x="316.19144602851327" y="112" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">108 µs</text>
+  <text x="250" y="149" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">SQLite (CsSqlite, prepared + immutable)</text>
+  <path d="M262 138 h46.04 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-46.04 Z" fill="#7c7b74"/>
+  <text x="320.040733197556" y="149" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">117 µs</text>
+  <text x="250" y="186" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">RocksDB</text>
+  <path d="M262 175 h416.00 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-416 Z" fill="#7c7b74"/>
+  <text x="690" y="186" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">982 µs</text>
+    <text x="24" y="230" font-size="10.5" fill="#8a897f">BenchmarkDotNet · .NET 10 · Apple M-series · 10,000 rows (int64 key, 13-byte value) · 4 KB pages</text>
+  </g>
+</svg>

--- a/docs/benchmarks/count_range_light.svg
+++ b/docs/benchmarks/count_range_light.svg
@@ -5,16 +5,17 @@
     <text x="24" y="48" font-size="11.5" fill="#52514e">Count 8,000 rows in a key range — time per query (lower is better)</text>
     <line x1="262" y1="58" x2="262" y2="203" stroke="#d8d7d2" stroke-width="1"/>
   <text x="250" y="75" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">DryDB</text>
-  <path d="M262 64 h3.25 a3.25050916496945 3.25050916496945 0 0 1 3.25050916496945 3.25050916496945 v15.498981670061099 a3.25050916496945 3.25050916496945 0 0 1 -3.25050916496945 3.25050916496945 h-3.25 Z" fill="#2a78d6"/>
-  <text x="276.5010183299389" y="75" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">15.2 µs</text>
+  <path d="M262 64 h43.45 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-43.45 Z" fill="#2a78d6"/>
+  <text x="317.44704570791527" y="75" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">15.2 µs</text>
   <text x="250" y="112" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">SQLite (CsSqlite, default)</text>
-  <path d="M262 101 h42.19 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-42.19 Z" fill="#7c7b74"/>
-  <text x="316.19144602851327" y="112" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">108 µs</text>
+  <path d="M262 101 h333.12 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-333.12 Z" fill="#7c7b74"/>
+  <text x="607.123745819398" y="112" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">108 µs</text>
   <text x="250" y="149" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">SQLite (CsSqlite, prepared + immutable)</text>
-  <path d="M262 138 h46.04 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-46.04 Z" fill="#7c7b74"/>
-  <text x="320.040733197556" y="149" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">117 µs</text>
+  <path d="M262 138 h361.22 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-361.22 Z" fill="#7c7b74"/>
+  <text x="635.2173913043479" y="149" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">117 µs</text>
   <text x="250" y="186" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">RocksDB</text>
   <path d="M262 175 h416.00 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-416 Z" fill="#7c7b74"/>
+  <path d="M606.4 173 l-6 26 h7 l6 -26 Z" fill="#fcfcfb"/>
   <text x="690" y="186" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">982 µs</text>
     <text x="24" y="230" font-size="10.5" fill="#8a897f">BenchmarkDotNet · .NET 10 · Apple M-series · 10,000 rows (int64 key, 13-byte value) · 4 KB pages</text>
   </g>

--- a/docs/benchmarks/point_lookup_dark.svg
+++ b/docs/benchmarks/point_lookup_dark.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 242" width="800" height="242" role="img" aria-label="Point lookup benchmark">
+  <rect x="0.5" y="0.5" width="799" height="241" rx="8" fill="#1a1a19" stroke="#33322f"/>
+  <g font-family="ui-sans-serif, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif">
+    <text x="24" y="30" font-size="15" font-weight="600" fill="#ffffff">Point lookup</text>
+    <text x="24" y="48" font-size="11.5" fill="#c3c2b7">Find one value by key, 10,000 rows — time per query (lower is better)</text>
+    <line x1="262" y1="58" x2="262" y2="203" stroke="#3a3936" stroke-width="1"/>
+  <text x="250" y="75" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">DryDB</text>
+  <path d="M262 64 h1.50 a1.5 1.5 0 0 1 1.5 1.5 v19 a1.5 1.5 0 0 1 -1.5 1.5 h-1.5 Z" fill="#3987e5"/>
+  <text x="273" y="75" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">29 ns</text>
+  <text x="250" y="112" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">RocksDB</text>
+  <path d="M262 101 h11.21 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-11.21 Z" fill="#8d8c82"/>
+  <text x="285.2073317307692" y="112" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">241 ns</text>
+  <text x="250" y="149" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">SQLite (CsSqlite, prepared + immutable)</text>
+  <path d="M262 138 h55.50 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-55.5 Z" fill="#8d8c82"/>
+  <text x="329.5042067307692" y="149" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">943 ns</text>
+  <text x="250" y="186" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">SQLite (CsSqlite, default)</text>
+  <path d="M262 175 h416.00 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-416 Z" fill="#8d8c82"/>
+  <text x="690" y="186" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">6,656 ns</text>
+    <text x="24" y="230" font-size="10.5" fill="#8a897f">BenchmarkDotNet · .NET 10 · Apple M-series · 10,000 rows (int64 key, 13-byte value) · 4 KB pages</text>
+  </g>
+</svg>

--- a/docs/benchmarks/point_lookup_dark.svg
+++ b/docs/benchmarks/point_lookup_dark.svg
@@ -5,16 +5,17 @@
     <text x="24" y="48" font-size="11.5" fill="#c3c2b7">Find one value by key, 10,000 rows — time per query (lower is better)</text>
     <line x1="262" y1="58" x2="262" y2="203" stroke="#3a3936" stroke-width="1"/>
   <text x="250" y="75" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">DryDB</text>
-  <path d="M262 64 h1.50 a1.5 1.5 0 0 1 1.5 1.5 v19 a1.5 1.5 0 0 1 -1.5 1.5 h-1.5 Z" fill="#3987e5"/>
-  <text x="273" y="75" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">29 ns</text>
+  <path d="M262 64 h7.23 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-7.23 Z" fill="#3987e5"/>
+  <text x="281.2314998386279" y="75" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">29 ns</text>
   <text x="250" y="112" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">RocksDB</text>
-  <path d="M262 101 h11.21 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-11.21 Z" fill="#8d8c82"/>
-  <text x="285.2073317307692" y="112" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">241 ns</text>
+  <path d="M262 101 h89.34 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-89.34 Z" fill="#8d8c82"/>
+  <text x="363.3376365899765" y="112" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">241 ns</text>
   <text x="250" y="149" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">SQLite (CsSqlite, prepared + immutable)</text>
-  <path d="M262 138 h55.50 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-55.5 Z" fill="#8d8c82"/>
-  <text x="329.5042067307692" y="149" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">943 ns</text>
+  <path d="M262 138 h361.22 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-361.22 Z" fill="#8d8c82"/>
+  <text x="635.217391304348" y="149" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">943 ns</text>
   <text x="250" y="186" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">SQLite (CsSqlite, default)</text>
   <path d="M262 175 h416.00 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-416 Z" fill="#8d8c82"/>
+  <path d="M606.4 173 l-6 26 h7 l6 -26 Z" fill="#1a1a19"/>
   <text x="690" y="186" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">6,656 ns</text>
     <text x="24" y="230" font-size="10.5" fill="#8a897f">BenchmarkDotNet · .NET 10 · Apple M-series · 10,000 rows (int64 key, 13-byte value) · 4 KB pages</text>
   </g>

--- a/docs/benchmarks/point_lookup_light.svg
+++ b/docs/benchmarks/point_lookup_light.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 242" width="800" height="242" role="img" aria-label="Point lookup benchmark">
+  <rect x="0.5" y="0.5" width="799" height="241" rx="8" fill="#fcfcfb" stroke="#e6e5e0"/>
+  <g font-family="ui-sans-serif, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif">
+    <text x="24" y="30" font-size="15" font-weight="600" fill="#0b0b0b">Point lookup</text>
+    <text x="24" y="48" font-size="11.5" fill="#52514e">Find one value by key, 10,000 rows — time per query (lower is better)</text>
+    <line x1="262" y1="58" x2="262" y2="203" stroke="#d8d7d2" stroke-width="1"/>
+  <text x="250" y="75" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">DryDB</text>
+  <path d="M262 64 h1.50 a1.5 1.5 0 0 1 1.5 1.5 v19 a1.5 1.5 0 0 1 -1.5 1.5 h-1.5 Z" fill="#2a78d6"/>
+  <text x="273" y="75" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">29 ns</text>
+  <text x="250" y="112" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">RocksDB</text>
+  <path d="M262 101 h11.21 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-11.21 Z" fill="#7c7b74"/>
+  <text x="285.2073317307692" y="112" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">241 ns</text>
+  <text x="250" y="149" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">SQLite (CsSqlite, prepared + immutable)</text>
+  <path d="M262 138 h55.50 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-55.5 Z" fill="#7c7b74"/>
+  <text x="329.5042067307692" y="149" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">943 ns</text>
+  <text x="250" y="186" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">SQLite (CsSqlite, default)</text>
+  <path d="M262 175 h416.00 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-416 Z" fill="#7c7b74"/>
+  <text x="690" y="186" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">6,656 ns</text>
+    <text x="24" y="230" font-size="10.5" fill="#8a897f">BenchmarkDotNet · .NET 10 · Apple M-series · 10,000 rows (int64 key, 13-byte value) · 4 KB pages</text>
+  </g>
+</svg>

--- a/docs/benchmarks/point_lookup_light.svg
+++ b/docs/benchmarks/point_lookup_light.svg
@@ -5,16 +5,17 @@
     <text x="24" y="48" font-size="11.5" fill="#52514e">Find one value by key, 10,000 rows — time per query (lower is better)</text>
     <line x1="262" y1="58" x2="262" y2="203" stroke="#d8d7d2" stroke-width="1"/>
   <text x="250" y="75" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">DryDB</text>
-  <path d="M262 64 h1.50 a1.5 1.5 0 0 1 1.5 1.5 v19 a1.5 1.5 0 0 1 -1.5 1.5 h-1.5 Z" fill="#2a78d6"/>
-  <text x="273" y="75" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">29 ns</text>
+  <path d="M262 64 h7.23 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-7.23 Z" fill="#2a78d6"/>
+  <text x="281.2314998386279" y="75" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">29 ns</text>
   <text x="250" y="112" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">RocksDB</text>
-  <path d="M262 101 h11.21 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-11.21 Z" fill="#7c7b74"/>
-  <text x="285.2073317307692" y="112" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">241 ns</text>
+  <path d="M262 101 h89.34 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-89.34 Z" fill="#7c7b74"/>
+  <text x="363.3376365899765" y="112" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">241 ns</text>
   <text x="250" y="149" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">SQLite (CsSqlite, prepared + immutable)</text>
-  <path d="M262 138 h55.50 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-55.5 Z" fill="#7c7b74"/>
-  <text x="329.5042067307692" y="149" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">943 ns</text>
+  <path d="M262 138 h361.22 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-361.22 Z" fill="#7c7b74"/>
+  <text x="635.217391304348" y="149" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">943 ns</text>
   <text x="250" y="186" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">SQLite (CsSqlite, default)</text>
   <path d="M262 175 h416.00 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-416 Z" fill="#7c7b74"/>
+  <path d="M606.4 173 l-6 26 h7 l6 -26 Z" fill="#fcfcfb"/>
   <text x="690" y="186" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">6,656 ns</text>
     <text x="24" y="230" font-size="10.5" fill="#8a897f">BenchmarkDotNet · .NET 10 · Apple M-series · 10,000 rows (int64 key, 13-byte value) · 4 KB pages</text>
   </g>

--- a/docs/benchmarks/range_scan_dark.svg
+++ b/docs/benchmarks/range_scan_dark.svg
@@ -5,17 +5,17 @@
     <text x="24" y="48" font-size="11.5" fill="#c3c2b7">Read 100 consecutive rows by key range — time per query (lower is better)</text>
     <line x1="262" y1="58" x2="262" y2="203" stroke="#3a3936" stroke-width="1"/>
   <text x="250" y="75" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">DryDB</text>
-  <path d="M262 64 h29.79 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-29.79 Z" fill="#3987e5"/>
-  <text x="303.7931034482759" y="75" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">1.4 µs</text>
+  <path d="M262 64 h25.39 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-25.39 Z" fill="#3987e5"/>
+  <text x="299.38530734632684" y="75" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">1.4 µs</text>
   <text x="250" y="112" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">SQLite (CsSqlite, prepared + immutable)</text>
-  <path d="M262 101 h227.72 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-227.72 Z" fill="#8d8c82"/>
-  <text x="501.7241379310345" y="112" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">9.6 µs</text>
+  <path d="M262 101 h197.50 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-197.5 Z" fill="#8d8c82"/>
+  <text x="471.4992503748126" y="112" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">9.6 µs</text>
   <text x="250" y="149" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">RocksDB</text>
-  <path d="M262 138 h333.93 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-333.93 Z" fill="#8d8c82"/>
-  <text x="607.9310344827586" y="149" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">14 µs</text>
+  <path d="M262 138 h289.85 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-289.85 Z" fill="#8d8c82"/>
+  <text x="563.8530734632684" y="149" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">14 µs</text>
   <text x="250" y="186" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">SQLite (CsSqlite, default)</text>
-  <path d="M262 175 h416.00 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-416 Z" fill="#8d8c82"/>
-  <text x="690" y="186" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">17.4 µs</text>
+  <path d="M262 175 h361.22 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-361.22 Z" fill="#8d8c82"/>
+  <text x="635.2173913043478" y="186" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">17.4 µs</text>
     <text x="24" y="230" font-size="10.5" fill="#8a897f">BenchmarkDotNet · .NET 10 · Apple M-series · 10,000 rows (int64 key, 13-byte value) · 4 KB pages</text>
   </g>
 </svg>

--- a/docs/benchmarks/range_scan_dark.svg
+++ b/docs/benchmarks/range_scan_dark.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 242" width="800" height="242" role="img" aria-label="Range scan benchmark">
+  <rect x="0.5" y="0.5" width="799" height="241" rx="8" fill="#1a1a19" stroke="#33322f"/>
+  <g font-family="ui-sans-serif, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif">
+    <text x="24" y="30" font-size="15" font-weight="600" fill="#ffffff">Range scan</text>
+    <text x="24" y="48" font-size="11.5" fill="#c3c2b7">Read 100 consecutive rows by key range — time per query (lower is better)</text>
+    <line x1="262" y1="58" x2="262" y2="203" stroke="#3a3936" stroke-width="1"/>
+  <text x="250" y="75" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">DryDB</text>
+  <path d="M262 64 h29.79 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-29.79 Z" fill="#3987e5"/>
+  <text x="303.7931034482759" y="75" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">1.4 µs</text>
+  <text x="250" y="112" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">SQLite (CsSqlite, prepared + immutable)</text>
+  <path d="M262 101 h227.72 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-227.72 Z" fill="#8d8c82"/>
+  <text x="501.7241379310345" y="112" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">9.6 µs</text>
+  <text x="250" y="149" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">RocksDB</text>
+  <path d="M262 138 h333.93 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-333.93 Z" fill="#8d8c82"/>
+  <text x="607.9310344827586" y="149" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">14 µs</text>
+  <text x="250" y="186" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">SQLite (CsSqlite, default)</text>
+  <path d="M262 175 h416.00 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-416 Z" fill="#8d8c82"/>
+  <text x="690" y="186" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">17.4 µs</text>
+    <text x="24" y="230" font-size="10.5" fill="#8a897f">BenchmarkDotNet · .NET 10 · Apple M-series · 10,000 rows (int64 key, 13-byte value) · 4 KB pages</text>
+  </g>
+</svg>

--- a/docs/benchmarks/range_scan_light.svg
+++ b/docs/benchmarks/range_scan_light.svg
@@ -5,17 +5,17 @@
     <text x="24" y="48" font-size="11.5" fill="#52514e">Read 100 consecutive rows by key range — time per query (lower is better)</text>
     <line x1="262" y1="58" x2="262" y2="203" stroke="#d8d7d2" stroke-width="1"/>
   <text x="250" y="75" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">DryDB</text>
-  <path d="M262 64 h29.79 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-29.79 Z" fill="#2a78d6"/>
-  <text x="303.7931034482759" y="75" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">1.4 µs</text>
+  <path d="M262 64 h25.39 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-25.39 Z" fill="#2a78d6"/>
+  <text x="299.38530734632684" y="75" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">1.4 µs</text>
   <text x="250" y="112" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">SQLite (CsSqlite, prepared + immutable)</text>
-  <path d="M262 101 h227.72 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-227.72 Z" fill="#7c7b74"/>
-  <text x="501.7241379310345" y="112" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">9.6 µs</text>
+  <path d="M262 101 h197.50 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-197.5 Z" fill="#7c7b74"/>
+  <text x="471.4992503748126" y="112" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">9.6 µs</text>
   <text x="250" y="149" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">RocksDB</text>
-  <path d="M262 138 h333.93 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-333.93 Z" fill="#7c7b74"/>
-  <text x="607.9310344827586" y="149" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">14 µs</text>
+  <path d="M262 138 h289.85 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-289.85 Z" fill="#7c7b74"/>
+  <text x="563.8530734632684" y="149" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">14 µs</text>
   <text x="250" y="186" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">SQLite (CsSqlite, default)</text>
-  <path d="M262 175 h416.00 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-416 Z" fill="#7c7b74"/>
-  <text x="690" y="186" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">17.4 µs</text>
+  <path d="M262 175 h361.22 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-361.22 Z" fill="#7c7b74"/>
+  <text x="635.2173913043478" y="186" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">17.4 µs</text>
     <text x="24" y="230" font-size="10.5" fill="#8a897f">BenchmarkDotNet · .NET 10 · Apple M-series · 10,000 rows (int64 key, 13-byte value) · 4 KB pages</text>
   </g>
 </svg>

--- a/docs/benchmarks/range_scan_light.svg
+++ b/docs/benchmarks/range_scan_light.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 242" width="800" height="242" role="img" aria-label="Range scan benchmark">
+  <rect x="0.5" y="0.5" width="799" height="241" rx="8" fill="#fcfcfb" stroke="#e6e5e0"/>
+  <g font-family="ui-sans-serif, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif">
+    <text x="24" y="30" font-size="15" font-weight="600" fill="#0b0b0b">Range scan</text>
+    <text x="24" y="48" font-size="11.5" fill="#52514e">Read 100 consecutive rows by key range — time per query (lower is better)</text>
+    <line x1="262" y1="58" x2="262" y2="203" stroke="#d8d7d2" stroke-width="1"/>
+  <text x="250" y="75" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">DryDB</text>
+  <path d="M262 64 h29.79 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-29.79 Z" fill="#2a78d6"/>
+  <text x="303.7931034482759" y="75" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">1.4 µs</text>
+  <text x="250" y="112" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">SQLite (CsSqlite, prepared + immutable)</text>
+  <path d="M262 101 h227.72 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-227.72 Z" fill="#7c7b74"/>
+  <text x="501.7241379310345" y="112" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">9.6 µs</text>
+  <text x="250" y="149" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">RocksDB</text>
+  <path d="M262 138 h333.93 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-333.93 Z" fill="#7c7b74"/>
+  <text x="607.9310344827586" y="149" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">14 µs</text>
+  <text x="250" y="186" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">SQLite (CsSqlite, default)</text>
+  <path d="M262 175 h416.00 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-416 Z" fill="#7c7b74"/>
+  <text x="690" y="186" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">17.4 µs</text>
+    <text x="24" y="230" font-size="10.5" fill="#8a897f">BenchmarkDotNet · .NET 10 · Apple M-series · 10,000 rows (int64 key, 13-byte value) · 4 KB pages</text>
+  </g>
+</svg>

--- a/sandbox/DryDB.Benchmark/CountBenchmark.cs
+++ b/sandbox/DryDB.Benchmark/CountBenchmark.cs
@@ -1,0 +1,99 @@
+using System.Buffers.Binary;
+using BenchmarkDotNet.Attributes;
+using CsSqlite;
+
+namespace DryDB.Benchmark;
+
+/// <summary>
+/// Count rows in a range: 8000 rows per query.
+/// </summary>
+[Config(typeof(BenchmarkConfig))]
+public class CountBenchmark : StoreBenchmarkBase
+{
+    const int Iterations = 100;
+    const long RangeStart = 1000;
+    const long RangeEnd = 8999; // inclusive, 8000 rows
+
+    SqliteCommand preparedCountCommand = default!;
+
+    protected override void OnSetup()
+    {
+        preparedCountCommand = cssqliteImmutableConnection.CreateCommand(
+            "SELECT COUNT(*) FROM items WHERE id >= $a AND id <= $b");
+    }
+
+    protected override void OnCleanup()
+    {
+        preparedCountCommand.Dispose();
+    }
+
+    [Benchmark(Baseline = true)]
+    public int DryDB_CountRange()
+    {
+        Span<byte> startKey = stackalloc byte[sizeof(long)];
+        Span<byte> endKey = stackalloc byte[sizeof(long)];
+        BinaryPrimitives.WriteInt64LittleEndian(startKey, RangeStart);
+        BinaryPrimitives.WriteInt64LittleEndian(endKey, RangeEnd);
+
+        var total = 0;
+        for (var i = 0; i < Iterations; i++)
+        {
+            var table = database.GetTable("items");
+            total += table.CountRange(startKey, endKey);
+        }
+        return total;
+    }
+
+    [Benchmark]
+    public long CsSqlite_CountRange()
+    {
+        var total = 0L;
+        for (var i = 0; i < Iterations; i++)
+        {
+            using var command = cssqliteConnection.CreateCommand(
+                "SELECT COUNT(*) FROM items WHERE id >= $a AND id <= $b");
+
+            command.Parameters.Add("$a", RangeStart);
+            command.Parameters.Add("$b", RangeEnd);
+            using var reader = command.ExecuteReader();
+            reader.Read();
+            total += reader.GetInt64(0);
+        }
+        return total;
+    }
+
+    // Fair read-only configuration: immutable=1 + prepared statement reuse
+    [Benchmark]
+    public long CsSqlite_CountRange_Fair()
+    {
+        var total = 0L;
+        for (var i = 0; i < Iterations; i++)
+        {
+            preparedCountCommand.Parameters.Add("$a", RangeStart);
+            preparedCountCommand.Parameters.Add("$b", RangeEnd);
+            using var reader = preparedCountCommand.ExecuteReader();
+            reader.Read();
+            total += reader.GetInt64(0);
+        }
+        return total;
+    }
+
+    [Benchmark]
+    public int RocksDB_CountRange()
+    {
+        var startKey = new byte[sizeof(long)];
+        BinaryPrimitives.WriteInt64BigEndian(startKey, RangeStart);
+
+        var total = 0;
+        for (var i = 0; i < Iterations; i++)
+        {
+            using var iterator = rocksDb.NewIterator();
+            for (iterator.Seek(startKey); iterator.Valid(); iterator.Next())
+            {
+                if (BinaryPrimitives.ReadInt64BigEndian(iterator.Key()) > RangeEnd) break;
+                total++;
+            }
+        }
+        return total;
+    }
+}

--- a/sandbox/DryDB.Benchmark/DryDB.Benchmark.csproj
+++ b/sandbox/DryDB.Benchmark/DryDB.Benchmark.csproj
@@ -11,6 +11,7 @@
     <ItemGroup>
       <PackageReference Include="BenchmarkDotNet" Version="0.15.6" />
       <PackageReference Include="CsSqlite" Version="1.1.0" />
+      <PackageReference Include="RocksDB" Version="10.10.1.1747" />
       <PackageReference Include="System.Data.SQLite" Version="2.0.2" />
     </ItemGroup>
 

--- a/sandbox/DryDB.Benchmark/RangeBenchmark.cs
+++ b/sandbox/DryDB.Benchmark/RangeBenchmark.cs
@@ -1,0 +1,107 @@
+using System.Buffers.Binary;
+using BenchmarkDotNet.Attributes;
+using CsSqlite;
+
+namespace DryDB.Benchmark;
+
+/// <summary>
+/// Range scan: 100 consecutive rows per query.
+/// </summary>
+[Config(typeof(BenchmarkConfig))]
+public class RangeBenchmark : StoreBenchmarkBase
+{
+    const int Iterations = 100;
+    const long RangeStart = 2000;
+    const long RangeEnd = 2099; // inclusive, 100 rows
+
+    SqliteCommand preparedRangeCommand = default!;
+
+    protected override void OnSetup()
+    {
+        preparedRangeCommand = cssqliteImmutableConnection.CreateCommand(
+            "SELECT data FROM items WHERE id >= $a AND id <= $b");
+    }
+
+    protected override void OnCleanup()
+    {
+        preparedRangeCommand.Dispose();
+    }
+
+    [Benchmark(Baseline = true)]
+    public int DryDB_GetRange()
+    {
+        Span<byte> startKey = stackalloc byte[sizeof(long)];
+        Span<byte> endKey = stackalloc byte[sizeof(long)];
+        BinaryPrimitives.WriteInt64LittleEndian(startKey, RangeStart);
+        BinaryPrimitives.WriteInt64LittleEndian(endKey, RangeEnd);
+
+        var total = 0;
+        for (var i = 0; i < Iterations; i++)
+        {
+            var table = database.GetTable("items");
+            using var result = table.GetRange(startKey, endKey);
+            foreach (var value in result)
+            {
+                total += value.Length;
+            }
+        }
+        return total;
+    }
+
+    [Benchmark]
+    public int CsSqlite_GetRange()
+    {
+        var total = 0;
+        for (var i = 0; i < Iterations; i++)
+        {
+            using var command = cssqliteConnection.CreateCommand(
+                "SELECT data FROM items WHERE id >= $a AND id <= $b");
+
+            command.Parameters.Add("$a", RangeStart);
+            command.Parameters.Add("$b", RangeEnd);
+            using var reader = command.ExecuteReader();
+            while (reader.Read())
+            {
+                total += reader.GetString(0).Length;
+            }
+        }
+        return total;
+    }
+
+    // Fair read-only configuration: immutable=1 + prepared statement reuse
+    [Benchmark]
+    public int CsSqlite_GetRange_Fair()
+    {
+        var total = 0;
+        for (var i = 0; i < Iterations; i++)
+        {
+            preparedRangeCommand.Parameters.Add("$a", RangeStart);
+            preparedRangeCommand.Parameters.Add("$b", RangeEnd);
+            using var reader = preparedRangeCommand.ExecuteReader();
+            while (reader.Read())
+            {
+                total += reader.GetString(0).Length;
+            }
+        }
+        return total;
+    }
+
+    [Benchmark]
+    public int RocksDB_GetRange()
+    {
+        var startKey = new byte[sizeof(long)];
+        BinaryPrimitives.WriteInt64BigEndian(startKey, RangeStart);
+
+        var total = 0;
+        for (var i = 0; i < Iterations; i++)
+        {
+            using var iterator = rocksDb.NewIterator();
+            for (iterator.Seek(startKey); iterator.Valid(); iterator.Next())
+            {
+                if (BinaryPrimitives.ReadInt64BigEndian(iterator.Key()) > RangeEnd) break;
+                total += iterator.Value().Length;
+            }
+        }
+        return total;
+    }
+}

--- a/sandbox/DryDB.Benchmark/ReadBenchmark.cs
+++ b/sandbox/DryDB.Benchmark/ReadBenchmark.cs
@@ -1,110 +1,35 @@
-using System.Text;
+using System.Buffers.Binary;
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Configs;
-using BenchmarkDotNet.Diagnosers;
-using BenchmarkDotNet.Jobs;
 using CsSqlite;
 
 namespace DryDB.Benchmark;
 
-class BenchmarkConfig : ManualConfig
-{
-    public BenchmarkConfig()
-    {
-        AddDiagnoser(MemoryDiagnoser.Default);
-        AddJob(Job.ShortRun
-            .WithWarmupCount(10)
-            .WithIterationCount(10)
-        );
-    }
-}
-
 [Config(typeof(BenchmarkConfig))]
-public class ReadBenchmark
+public class ReadBenchmark : StoreBenchmarkBase
 {
-    const int N = 10000;
+    const int Iterations = 1000;
+    const long FindKey = 123;
 
-    DirectoryInfo directory;
-    ReadOnlyDatabase database;
-    SqliteConnection cssqliteConnection;
-    System.Data.SQLite.SQLiteConnection systemSqliteConnection;
+    SqliteCommand preparedFindCommand = default!;
 
-    string findKey = "key0000001234";
-
-    [GlobalSetup]
-    public async Task CreateDB()
+    protected override void OnSetup()
     {
-        directory = Directory.CreateTempSubdirectory("drydb_benchmarks");
-        var sqlitePath = Path.Combine(directory.FullName, "bench.sqlite");
-        var drydbPath = Path.Combine(directory.FullName, "bench.drydb");
-
-        // Setup sqlite
-        using (var sqlite = new SqliteConnection(sqlitePath))
-        {
-            sqlite.Open();
-
-            sqlite.ExecuteNonQuery("DROP TABLE IF EXISTS items;");
-
-            sqlite.ExecuteNonQuery("PRAGMA page_size = 4096;");
-
-            sqlite.ExecuteNonQuery(
-                """
-                CREATE TABLE IF NOT EXISTS items (
-                    id INTEGER NOT NULL PRIMARY KEY,
-                    data TEXT NOT NULL
-                );
-                """);
-
-            for (var i = 0; i < N; i++)
-            {
-                sqlite.ExecuteNonQuery(
-                    $"""
-                     INSERT INTO items (id, data) VALUES ({i}, 'val{i:D10}');
-                     """);
-            }
-        }
-
-        // Setup  DryDB
-        using var builder = new DatabaseBuilder
-        {
-            PageSize = 4096,
-        };
-        var tableBuilder = builder.CreateTable("items", KeyEncoding.Int64LittleEndian);
-        for (var i = 0; i < N; i++)
-        {
-            tableBuilder.Append(i, Encoding.UTF8.GetBytes($"val{i:D10}"));
-        }
-        await builder.BuildToFileAsync(drydbPath);
-
-        database = await ReadOnlyDatabase.OpenFileAsync(drydbPath, new DatabaseLoadOptions
-        {
-        });
-
-        cssqliteConnection = new SqliteConnection(sqlitePath);
-        // systemSqliteConnection = new System.Data.SQLite.SQLiteConnection($"Data Source={sqlitePath}");
+        preparedFindCommand = cssqliteImmutableConnection.CreateCommand(
+            "SELECT data FROM items WHERE id = $id");
     }
 
-    [GlobalCleanup]
-    public void Cleanup()
+    protected override void OnCleanup()
     {
-        cssqliteConnection.Dispose();
-        // systemSqliteConnection.Dispose();
-        database.Dispose();
-
-        try
-        {
-            directory.Delete(true);
-        }
-        catch (DirectoryNotFoundException) { }
+        preparedFindCommand.Dispose();
     }
 
     [Benchmark(Baseline = true)]
     public void DryDB_FindByKey()
     {
-        for (var i = 0; i < 1000; i++)
+        for (var i = 0; i < Iterations; i++)
         {
             var table = database.GetTable("items");
-            using var _ = table.Get(123);
+            using var _ = table.Get(FindKey);
         }
     }
 
@@ -119,9 +44,9 @@ public class ReadBenchmark
             tasks[t] = Task.Run(() =>
             {
                 var table = database.GetTable("items");
-                for (var i = 0; i < 1000; i++)
+                for (var i = 0; i < Iterations; i++)
                 {
-                    using var _ = table.Get(123);
+                    using var _ = table.Get(FindKey);
                 }
             });
         }
@@ -131,29 +56,43 @@ public class ReadBenchmark
     [Benchmark]
     public void CsSqlite_FindByKey()
     {
-        for (var i = 0; i < 1000; i++)
+        for (var i = 0; i < Iterations; i++)
         {
             using var command = cssqliteConnection.CreateCommand(
                 "SELECT data FROM items WHERE id = $id");
 
-            command.Parameters.Add("$id", 123);
+            command.Parameters.Add("$id", FindKey);
             using var reader = command.ExecuteReader();
             reader.Read();
             reader.GetString(0);
         }
     }
-    //
-    // [Benchmark]
-    // public void SystemDataSql_FindByKey()
-    // {
-    //     for (var i = 0; i < 1000; i++)
-    //     {
-    //         using var command = systemSqliteConnection.CreateCommand();
-    //         command.CommandText = "SELECT data FROM items WHERE id = $id";
-    //         command.Parameters.AddWithValue("$id", 123);
-    //         using var reader = command.ExecuteReader();
-    //         reader.Read();
-    //         reader.GetString(0);
-    //     }
-    // }
+
+    // Fair read-only configuration: immutable=1 + prepared statement reuse
+    [Benchmark]
+    public void CsSqlite_FindByKey_Fair()
+    {
+        for (var i = 0; i < Iterations; i++)
+        {
+            preparedFindCommand.Parameters.Add("$id", FindKey);
+            using var reader = preparedFindCommand.ExecuteReader();
+            reader.Read();
+            reader.GetString(0);
+        }
+    }
+
+    [Benchmark]
+    public int RocksDB_FindByKey()
+    {
+        var key = new byte[sizeof(long)];
+        BinaryPrimitives.WriteInt64BigEndian(key, FindKey);
+
+        var total = 0;
+        for (var i = 0; i < Iterations; i++)
+        {
+            var value = rocksDb.Get(key);
+            total += value.Length;
+        }
+        return total;
+    }
 }

--- a/sandbox/DryDB.Benchmark/ReadBenchmark.cs
+++ b/sandbox/DryDB.Benchmark/ReadBenchmark.cs
@@ -108,6 +108,26 @@ public class ReadBenchmark
         }
     }
 
+    const int ThreadCount = 8;
+
+    [Benchmark]
+    public void DryDB_FindByKey_Parallel()
+    {
+        var tasks = new Task[ThreadCount];
+        for (var t = 0; t < ThreadCount; t++)
+        {
+            tasks[t] = Task.Run(() =>
+            {
+                var table = database.GetTable("items");
+                for (var i = 0; i < 1000; i++)
+                {
+                    using var _ = table.Get(123);
+                }
+            });
+        }
+        Task.WaitAll(tasks);
+    }
+
     [Benchmark]
     public void CsSqlite_FindByKey()
     {

--- a/sandbox/DryDB.Benchmark/StoreBenchmarkBase.cs
+++ b/sandbox/DryDB.Benchmark/StoreBenchmarkBase.cs
@@ -1,0 +1,136 @@
+using System.Buffers.Binary;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Jobs;
+using CsSqlite;
+using RocksDbSharp;
+
+namespace DryDB.Benchmark;
+
+class BenchmarkConfig : ManualConfig
+{
+    public BenchmarkConfig()
+    {
+        AddDiagnoser(MemoryDiagnoser.Default);
+        AddJob(Job.ShortRun
+            .WithWarmupCount(10)
+            .WithIterationCount(10)
+        );
+    }
+}
+
+/// <summary>
+/// Builds the same 10k-row dataset in SQLite (CsSqlite), DryDB and RocksDB.
+/// </summary>
+public abstract class StoreBenchmarkBase
+{
+    protected const int N = 10000;
+
+    protected ReadOnlyDatabase database = default!;
+
+    // sqlite: as-is defaults (command prepared per query)
+    protected SqliteConnection cssqliteConnection = default!;
+
+    // sqlite: fair read-only setup (immutable=1, prepared statements reused)
+    protected SqliteConnection cssqliteImmutableConnection = default!;
+
+    protected RocksDb rocksDb = default!;
+
+    DirectoryInfo directory = default!;
+
+    [GlobalSetup]
+    public async Task SetupAsync()
+    {
+        directory = Directory.CreateTempSubdirectory("drydb_benchmarks");
+        var sqlitePath = Path.Combine(directory.FullName, "bench.sqlite");
+        var drydbPath = Path.Combine(directory.FullName, "bench.drydb");
+        var rocksdbPath = Path.Combine(directory.FullName, "bench.rocksdb");
+
+        // Setup sqlite
+        using (var sqlite = new SqliteConnection(sqlitePath))
+        {
+            sqlite.Open();
+
+            sqlite.ExecuteNonQuery("DROP TABLE IF EXISTS items;");
+
+            sqlite.ExecuteNonQuery("PRAGMA page_size = 4096;");
+
+            sqlite.ExecuteNonQuery(
+                """
+                CREATE TABLE IF NOT EXISTS items (
+                    id INTEGER NOT NULL PRIMARY KEY,
+                    data TEXT NOT NULL
+                );
+                """);
+
+            sqlite.ExecuteNonQuery("BEGIN TRANSACTION;");
+            for (var i = 0; i < N; i++)
+            {
+                sqlite.ExecuteNonQuery(
+                    $"""
+                     INSERT INTO items (id, data) VALUES ({i}, 'val{i:D10}');
+                     """);
+            }
+            sqlite.ExecuteNonQuery("COMMIT;");
+        }
+
+        // Setup DryDB
+        using (var builder = new DatabaseBuilder
+               {
+                   PageSize = 4096,
+               })
+        {
+            var tableBuilder = builder.CreateTable("items", KeyEncoding.Int64LittleEndian);
+            for (var i = 0; i < N; i++)
+            {
+                tableBuilder.Append(i, Encoding.UTF8.GetBytes($"val{i:D10}"));
+            }
+            await builder.BuildToFileAsync(drydbPath);
+        }
+
+        // Setup RocksDB (big-endian keys so that the default bytewise comparator
+        // sorts them numerically, which range scans rely on)
+        var rocksDbOptions = new DbOptions().SetCreateIfMissing(true);
+        using (var db = RocksDb.Open(rocksDbOptions, rocksdbPath))
+        {
+            var keyBuffer = new byte[sizeof(long)];
+            for (var i = 0; i < N; i++)
+            {
+                BinaryPrimitives.WriteInt64BigEndian(keyBuffer, i);
+                db.Put(keyBuffer, Encoding.UTF8.GetBytes($"val{i:D10}"));
+            }
+        }
+
+        database = await ReadOnlyDatabase.OpenFileAsync(drydbPath, new DatabaseLoadOptions
+        {
+        });
+
+        cssqliteConnection = new SqliteConnection(sqlitePath);
+        cssqliteImmutableConnection = new SqliteConnection($"file:{sqlitePath}?immutable=1");
+        rocksDb = RocksDb.OpenReadOnly(rocksDbOptions, rocksdbPath, false);
+
+        OnSetup();
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        OnCleanup();
+
+        cssqliteConnection.Dispose();
+        cssqliteImmutableConnection.Dispose();
+        rocksDb.Dispose();
+        database.Dispose();
+
+        try
+        {
+            directory.Delete(true);
+        }
+        catch (DirectoryNotFoundException) { }
+    }
+
+    protected virtual void OnSetup() { }
+    protected virtual void OnCleanup() { }
+}

--- a/src/DryDB/BTree/InternalNodeReader.cs
+++ b/src/DryDB/BTree/InternalNodeReader.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
+using DryDB.Internal;
 
 namespace DryDB.BTree;
 
@@ -61,7 +62,7 @@ readonly ref struct InternalNodeReader(ReadOnlySpan<byte> page, int entryCount)
             ref var ptr = ref Unsafe.Add(ref pageReference, meta.PageOffset);
 
             var midKey = MemoryMarshal.CreateReadOnlySpan(ref ptr, meta.KeyLength);
-            var cmp = keyEncoding.Compare(midKey, key);
+            var cmp = KeyCompare.Compare(keyEncoding, midKey, key);
             if (cmp <= 0) // upper bounds
             {
                 min = mid + 1;

--- a/src/DryDB/BTree/LeafNodeReader.cs
+++ b/src/DryDB/BTree/LeafNodeReader.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
+using DryDB.Internal;
 
 namespace DryDB.BTree;
 
@@ -71,14 +72,39 @@ readonly ref struct LeafNodeReader(ReadOnlySpan<byte> page, int entryCount)
         out int valueOffset,
         out ushort valueLength)
     {
-        if (TrySearch(key, SearchOperator.Equal, keyEncoding, out index))
+#if NETSTANDARD
+        ref var pageReference = ref MemoryMarshal.GetReference(page);
+#endif
+        var min = 0;
+        var max = entryCount;
+
+        while (min < max)
         {
-            var meta = GetMeta(index);
-            valueOffset = meta.PageOffset + meta.KeyLength;
-            valueLength = meta.ValueLength;
-            return true;
+            var midIndex = min + ((max - min) >> 1);
+            var midMeta = GetMeta(midIndex);
+
+            ref var ptr = ref Unsafe.Add(ref pageReference, midMeta.PageOffset);
+            var midKey = MemoryMarshal.CreateReadOnlySpan(ref ptr, midMeta.KeyLength);
+
+            var compared = KeyCompare.Compare(keyEncoding, midKey, key);
+            if (compared == 0)
+            {
+                index = midIndex;
+                valueOffset = midMeta.PageOffset + midMeta.KeyLength;
+                valueLength = midMeta.ValueLength;
+                return true;
+            }
+            if (compared < 0)
+            {
+                min = midIndex + 1;
+            }
+            else
+            {
+                max = midIndex;
+            }
         }
 
+        index = default;
         valueOffset = default;
         valueLength = default;
         return false;
@@ -106,7 +132,7 @@ readonly ref struct LeafNodeReader(ReadOnlySpan<byte> page, int entryCount)
             ref var ptr = ref Unsafe.Add(ref pageReference, midMeta.PageOffset);
             var midKey = MemoryMarshal.CreateReadOnlySpan(ref ptr, midMeta.KeyLength);
 
-            var compared = keyEncoding.Compare(midKey, key);
+            var compared = KeyCompare.Compare(keyEncoding, midKey, key);
             switch (op)
             {
                 case SearchOperator.Equal:
@@ -166,7 +192,7 @@ readonly ref struct LeafNodeReader(ReadOnlySpan<byte> page, int entryCount)
                     var meta = GetMeta(min);
                     ref var ptr = ref Unsafe.Add(ref pageReference, meta.PageOffset);
                     var foundKey = MemoryMarshal.CreateReadOnlySpan(ref ptr, meta.KeyLength);
-                    if (keyEncoding.Compare(foundKey, key) == 0)
+                    if (KeyCompare.Compare(keyEncoding, foundKey, key) == 0)
                     {
                         index = min;
                         return true;

--- a/src/DryDB/BTree/TreeWalker.cs
+++ b/src/DryDB/BTree/TreeWalker.cs
@@ -516,10 +516,7 @@ class TreeWalker
             {
                 if (!nextPageNumber.HasValue) return 0;
 
-                while (!PageCache.TryGet(nextPageNumber.Value, out page))
-                {
-                    PageCache.Load(nextPageNumber.Value);
-                }
+                PageCache.Load(nextPageNumber.Value);
             }
         }
 
@@ -527,9 +524,13 @@ class TreeWalker
 
         while (true)
         {
+            // `page` is reassigned to the right sibling inside the loop; keep the
+            // reference we own so that the finally releases the page we walked,
+            // not the newly acquired one.
+            var currentPage = page;
             try
             {
-                var pageSpan = page.Memory.Span;
+                var pageSpan = currentPage.Memory.Span;
                 var header = NodeHeader.Parse(pageSpan);
                 if (header.Kind != NodeKind.Leaf)
                 {
@@ -577,7 +578,7 @@ class TreeWalker
             }
             finally
             {
-                page.Release();
+                currentPage.Release();
             }
         }
     }
@@ -618,10 +619,7 @@ class TreeWalker
             {
                 if (!nextPageNumber.HasValue) return 0;
 
-                while (!PageCache.TryGet(nextPageNumber.Value, out page))
-                {
-                    await PageCache.LoadAsync(nextPageNumber.Value, cancellationToken).ConfigureAwait(false);
-                }
+                await PageCache.LoadAsync(nextPageNumber.Value, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -629,9 +627,13 @@ class TreeWalker
 
         while (true)
         {
+            // `page` is reassigned to the right sibling inside the loop; keep the
+            // reference we own so that the finally releases the page we walked,
+            // not the newly acquired one.
+            var currentPage = page;
             try
             {
-                var pageSpan = page.Memory.Span;
+                var pageSpan = currentPage.Memory.Span;
                 var header = NodeHeader.Parse(pageSpan);
                 if (header.Kind != NodeKind.Leaf)
                 {
@@ -679,7 +681,7 @@ class TreeWalker
             }
             finally
             {
-                page.Release();
+                currentPage.Release();
             }
         }
     }

--- a/src/DryDB/BTree/TreeWalker.cs
+++ b/src/DryDB/BTree/TreeWalker.cs
@@ -22,6 +22,11 @@ class TreeWalker
 
     readonly IKeyEncoding comparer;
 
+    // The root page is touched by every lookup. Keep one retained reference here so the
+    // hot path can skip the cache lookup + refcount traffic for it. The pin lives for the
+    // lifetime of the TreeWalker; the underlying buffer is reclaimed by the GC afterwards.
+    IPageEntry? pinnedRoot;
+
     static readonly int BlobDataOffset = Unsafe.SizeOf<PageHeader>() + Unsafe.SizeOf<NodeHeader>();
 
     internal TreeWalker(
@@ -156,7 +161,7 @@ class TreeWalker
                         var key = MemoryMarshal.CreateReadOnlySpan(
                             ref Unsafe.Add(ref MemoryMarshal.GetReference(pageSpan), pageOffset),
                             keyLength);
-                        var compared = KeyEncoding.Compare(key, endKey);
+                        var compared = KeyCompare.Compare(comparer, key, endKey);
                         if (compared > 0 || (endKeyExclusive && compared == 0))
                         {
                             return result;
@@ -234,7 +239,7 @@ class TreeWalker
                         var key = MemoryMarshal.CreateReadOnlySpan(
                             ref Unsafe.Add(ref MemoryMarshal.GetReference(pageSpan), pageOffset),
                             keyLength);
-                        var compared = KeyEncoding.Compare(key, startKey);
+                        var compared = KeyCompare.Compare(comparer, key, startKey);
                         if (compared < 0 || (startKeyExclusive && compared == 0))
                         {
                             return result;
@@ -349,9 +354,10 @@ class TreeWalker
                     // check end key
                     if (!endKey.IsEmpty)
                     {
-                        var compared = KeyEncoding.Compare(
-                            currentPage.Memory.Slice(pageOffset, keyLength),
-                            endKey);
+                        var compared = KeyCompare.Compare(
+                            comparer,
+                            currentPage.Memory.Span.Slice(pageOffset, keyLength),
+                            endKey.Span);
                         if (compared > 0 || (endKeyExclusive && compared == 0))
                         {
                             return result;
@@ -430,9 +436,10 @@ class TreeWalker
                     // check start key (lower bound for descending)
                     if (!startKey.IsEmpty)
                     {
-                        var compared = KeyEncoding.Compare(
-                            currentPage.Memory.Slice(pageOffset, keyLength),
-                            startKey);
+                        var compared = KeyCompare.Compare(
+                            comparer,
+                            currentPage.Memory.Span.Slice(pageOffset, keyLength),
+                            startKey.Span);
                         if (compared < 0 || (startKeyExclusive && compared == 0))
                         {
                             return result;
@@ -544,7 +551,7 @@ class TreeWalker
                         var key = MemoryMarshal.CreateReadOnlySpan(
                             ref Unsafe.Add(ref MemoryMarshal.GetReference(pageSpan), pageOffset),
                             keyLength);
-                        var compared = KeyEncoding.Compare(key, endKey);
+                        var compared = KeyCompare.Compare(comparer, key, endKey);
                         if (compared > 0 || (endKeyExclusive && compared == 0))
                         {
                             return count;
@@ -646,7 +653,7 @@ class TreeWalker
                         var key = MemoryMarshal.CreateReadOnlySpan(
                             ref Unsafe.Add(ref MemoryMarshal.GetReference(pageSpan), pageOffset),
                             keyLength);
-                        var compared = KeyEncoding.Compare(key, endKey.Span);
+                        var compared = KeyCompare.Compare(comparer, key, endKey.Span);
                         if (compared > 0 || (endKeyExclusive && compared == 0))
                         {
                             return count;
@@ -730,7 +737,7 @@ class TreeWalker
         var pageNumber = from;
         while (true)
         {
-            if (!PageCache.TryGet(pageNumber, out var page))
+            if (!TryGetPage(pageNumber, out var page, out var pinned))
             {
                 entryIndex = default;
                 value = default;
@@ -743,42 +750,79 @@ class TreeWalker
             if (header.Kind == NodeKind.Internal)
             {
                 var internalNode = new InternalNodeReader(pageSpan, header.EntryCount);
-                if (!internalNode.TrySearch(key, KeyEncoding, out pageNumber))
+                if (!internalNode.TrySearch(key, comparer, out pageNumber))
                 {
-                    page.Release();
+                    if (!pinned) page.Release();
                     entryIndex = default;
                     value = default;
                     next = null;
                     return false;
                 }
 
-                page.Release();
+                if (!pinned) page.Release();
             }
             else // Leaf
             {
                 next = null;
 
                 var leafNode = new LeafNodeReader(pageSpan, header.EntryCount);
-                if (leafNode.TryFindValue(key, KeyEncoding, out entryIndex, out var valueOffset, out var valueLength))
+                if (leafNode.TryFindValue(key, comparer, out entryIndex, out var valueOffset, out var valueLength))
                 {
                     if (LeafNodeReader.IsOverflow(valueLength))
                     {
                         var resolved = ResolveValue(page, valueOffset, valueLength);
-                        page.Release();
+                        if (!pinned) page.Release();
                         value = resolved;
                     }
                     else
                     {
+                        // The caller releases the page via PageSlice.Dispose; the pin must
+                        // stay balanced, so hand out an extra reference.
+                        if (pinned) page.Retain();
                         value = new PageSlice(page, valueOffset, valueLength);
                     }
                     return true;
                 }
 
-                page.Release();
+                if (!pinned) page.Release();
                 value = default;
                 return false;
             }
         }
+    }
+
+    /// <summary>
+    /// Get a page from the cache. The root page is served from <see cref="pinnedRoot"/>
+    /// without touching the cache; <paramref name="pinned"/> indicates that the returned
+    /// entry holds no extra reference and must not be released by the caller.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    bool TryGetPage(PageNumber pageNumber, out IPageEntry page, out bool pinned)
+    {
+        if (pageNumber == RootPageNumber)
+        {
+            var root = pinnedRoot;
+            if (root != null)
+            {
+                page = root;
+                pinned = true;
+                return true;
+            }
+
+            if (!PageCache.TryGet(pageNumber, out page))
+            {
+                pinned = false;
+                return false;
+            }
+
+            // Transfer the reference we just acquired to the pin. If another thread won
+            // the race, keep using our own reference (released by the caller as usual).
+            pinned = Interlocked.CompareExchange(ref pinnedRoot, page, null) == null;
+            return true;
+        }
+
+        pinned = false;
+        return PageCache.TryGet(pageNumber, out page);
     }
 
     internal bool TrySearch(
@@ -800,7 +844,7 @@ class TreeWalker
         var pageNumber = from;
         while (true)
         {
-            if (!PageCache.TryGet(pageNumber, out page))
+            if (!TryGetPage(pageNumber, out page, out var pinned))
             {
                 index = default;
                 nextPageNumber = pageNumber;
@@ -814,13 +858,13 @@ class TreeWalker
                 var internalNode = new InternalNodeReader(pageSpan, header.EntryCount);
                 if (!internalNode.TrySearch(key, comparer, out pageNumber))
                 {
-                    page.Release();
+                    if (!pinned) page.Release();
                     index = default;
                     nextPageNumber = null;
                     return false;
                 }
 
-                page.Release();
+                if (!pinned) page.Release();
             }
             else // Leaf
             {
@@ -829,10 +873,12 @@ class TreeWalker
                 var leafNode = new LeafNodeReader(pageSpan, header.EntryCount);
                 if (leafNode.TrySearch(key, op, comparer, out index))
                 {
+                    // The caller owns (and releases) the returned leaf page.
+                    if (pinned) page.Retain();
                     return true;
                 }
 
-                page.Release();
+                if (!pinned) page.Release();
                 index = default;
                 return false;
             }

--- a/src/DryDB/Internal/DuplicateKeyEncoding.cs
+++ b/src/DryDB/Internal/DuplicateKeyEncoding.cs
@@ -19,7 +19,7 @@ class DuplicateKeyEncoding(IKeyEncoding sourceEncoding) : IKeyEncoding
     {
         var aOriginal = a[..^sizeof(int)];
         var bOriginal = b[..^sizeof(int)];
-        var sourceResult = sourceEncoding.Compare(aOriginal, bOriginal);
+        var sourceResult = KeyCompare.Compare(sourceEncoding, aOriginal, bOriginal);
         if (sourceResult == 0)
         {
             ref var aPtr = ref MemoryMarshal.GetReference(a);

--- a/src/DryDB/Internal/KeyCompare.cs
+++ b/src/DryDB/Internal/KeyCompare.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace DryDB.Internal;
+
+/// <summary>
+/// Guarded devirtualization for the built-in key encodings.
+/// B+Tree search compares keys O(log n) times per node; going through
+/// <see cref="IKeyEncoding.Compare(ReadOnlySpan{byte}, ReadOnlySpan{byte})"/> costs an
+/// interface dispatch per comparison, which dominates on cached pages
+/// (and is never devirtualized on AOT targets such as IL2CPP).
+/// </summary>
+static class KeyCompare
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int Compare(IKeyEncoding keyEncoding, ReadOnlySpan<byte> a, ReadOnlySpan<byte> b)
+    {
+        if (ReferenceEquals(keyEncoding, Int64LittleEndianEncoding.Instance))
+        {
+            var na = Unsafe.ReadUnaligned<long>(ref MemoryMarshal.GetReference(a));
+            var nb = Unsafe.ReadUnaligned<long>(ref MemoryMarshal.GetReference(b));
+            return (na > nb ? 1 : 0) - (na < nb ? 1 : 0);
+        }
+        if (ReferenceEquals(keyEncoding, AsciiOrdinalEncoding.Instance))
+        {
+            return a.SequenceCompareTo(b);
+        }
+        return keyEncoding.Compare(a, b);
+    }
+}

--- a/src/DryDB/Internal/PageCache.cs
+++ b/src/DryDB/Internal/PageCache.cs
@@ -22,16 +22,28 @@ public sealed class PageCache : IDisposable
     class Entry : IPageEntry
     {
         public required PageNumber PageNumber { get; init; }
-        public required IMemoryOwner<byte>? Buffer { get; init; }
+        public required IMemoryOwner<byte>? Buffer
+        {
+            get => buffer;
+            init
+            {
+                buffer = value;
+                // cache the Memory to avoid the virtual IMemoryOwner<byte>.Memory call per access
+                memory = value?.Memory ?? default;
+            }
+        }
         public QueueTag Tag { get; set; }
 
         public int RefCount;
         public int Frequency;
 
+        IMemoryOwner<byte>? buffer;
+        readonly ReadOnlyMemory<byte> memory;
+
         public ReadOnlyMemory<byte> Memory
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => Buffer!.Memory;
+            get => memory;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -139,14 +151,12 @@ public sealed class PageCache : IDisposable
             }
 
             // freq++（max: 3）
-            while (true)
+            // Frequency is an approximate heuristic for S3-FIFO; a lost increment under
+            // contention is acceptable, so a single CAS attempt is enough (no retry loop).
+            var frequency = entry.Frequency;
+            if (frequency < 3)
             {
-                var frequency = entry.Frequency;
-                if (frequency >= 3) break;
-                if (Interlocked.CompareExchange(ref entry.Frequency, frequency + 1, frequency) == frequency)
-                {
-                    break;
-                }
+                Interlocked.CompareExchange(ref entry.Frequency, frequency + 1, frequency);
             }
             page = entry;
             return true;

--- a/src/DryDB/ReadOnlyDatabase.cs
+++ b/src/DryDB/ReadOnlyDatabase.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -53,6 +54,7 @@ public sealed class ReadOnlyDatabase : IDisposable
     public Catalog Catalog { get; }
     readonly IPageLoader pageLoader;
     readonly PageCache pageCache;
+    readonly Dictionary<string, ReadOnlyTable> tables;
 
     ReadOnlyDatabase(Catalog catalog, IPageLoader pageLoader, int cacheSize)
     {
@@ -60,6 +62,12 @@ public sealed class ReadOnlyDatabase : IDisposable
         this.pageLoader = pageLoader;
         var pageCacheCapacity = Math.Max(cacheSize / catalog.PageSize, 8);
         pageCache = new PageCache(pageLoader, pageCacheCapacity, catalog.Filters?.ToArray() ?? []);
+
+        tables = new Dictionary<string, ReadOnlyTable>(catalog.TableDescriptors.Count);
+        foreach (var descriptor in catalog.TableDescriptors.Values)
+        {
+            tables.Add(descriptor.Name, new ReadOnlyTable(descriptor, pageCache));
+        }
     }
 
     public void Dispose()
@@ -68,9 +76,5 @@ public sealed class ReadOnlyDatabase : IDisposable
         pageLoader.Dispose();
     }
 
-    public ReadOnlyTable GetTable(string name)
-    {
-        var descriptor = Catalog.TableDescriptors[name];
-        return new ReadOnlyTable(descriptor, pageCache);
-    }
+    public ReadOnlyTable GetTable(string name) => tables[name];
 }

--- a/tests/DryDB.Tests/ReadOnlyTableTest.cs
+++ b/tests/DryDB.Tests/ReadOnlyTableTest.cs
@@ -259,6 +259,40 @@ public class ReadOnlyTableTest
     }
 
     [Test]
+    public async Task CountRange_Repeated_DoesNotCorruptPageCache()
+    {
+        var table = await TestHelper.BuildTableAsync(
+            KeyEncoding.Ascii,
+            databaseConfigure: builder => builder.PageSize = 128,
+            tableConfigure: builder =>
+            {
+                for (var i = 0; i < 1000; i++)
+                {
+                    builder.Append(
+                        Encoding.ASCII.GetBytes($"key{i:D5}"),
+                        Encoding.ASCII.GetBytes($"value{i:D5}"));
+                }
+            });
+
+        // CountRange used to release the pages it walked one too many times, killing
+        // the cache entry for the last page of the range. Any later traversal through
+        // that page then spun forever in the TryGet/Load retry loop.
+        var completed = Task.Run(() =>
+        {
+            for (var i = 0; i < 3; i++)
+            {
+                var count = table.CountRange("key00100"u8, "key00900"u8);
+                Assert.That(count, Is.EqualTo(801));
+            }
+
+            using var result = table.Get("key00900"u8);
+            Assert.That(result.HasValue, Is.True);
+        }).Wait(TimeSpan.FromSeconds(10));
+
+        Assert.That(completed, Is.True, "CountRange corrupted the page cache (deadlock)");
+    }
+
+    [Test]
     public async Task GetRangeWithPrefix_Basic()
     {
         var table = await TestHelper.BuildTableAsync(


### PR DESCRIPTION
## Read hot-path optimization

Point lookup: **45.18 µs → ~25 µs per 1000 queries (≈1.8x), allocations 171.88 KB → 0**.

- **Cache `ReadOnlyTable` instances in `ReadOnlyDatabase`** — `GetTable` used to allocate a `ReadOnlyTable` + `TreeWalker` + `Dictionary` per call, which was all of the ~176 B/lookup allocation. Tables are now built once at open.
- **Devirtualize key comparison in B+Tree search** (`KeyCompare`) — the binary-search inner loop paid an interface dispatch per comparison via `IKeyEncoding.Compare`. A `ReferenceEquals` guard on the built-in encodings inlines the compare; this also helps AOT targets (IL2CPP) where dynamic PGO never devirtualizes. Also rewrote `LeafNodeReader.TryFindValue` as a dedicated Equal-search loop (no per-iteration `switch (op)`).
- **Pin the root page in `TreeWalker`** — every lookup touches the root, so keep one retained reference and skip the cache lookup + refcount round-trip for it. This also removes the root's refcount cache line as a multi-thread contention point.
- **`PageCache` micro-optimizations** — cache `IMemoryOwner.Memory` in the entry (avoids a virtual call per access) and relax the S3-FIFO frequency bump to a single CAS attempt (frequency is an approximate heuristic).

## Bug fix

- **Fix page over-release in `CountRange`** — same patch as #26 (cherry-picked here so the count benchmark can run; merges cleanly in either order). The sibling-walk loop released the newly acquired page instead of the finished one, eventually disposing a page buffer that was still in the cache map, after which any traversal through that page spun forever.

## Benchmarks

- Added **RocksDB** and a **fair read-only SQLite configuration** (`immutable=1` + prepared statement reuse — ~7x faster than the naive per-query command) as comparison targets.
- Added **range scan** (100 rows) and **count by key range** (8,000 rows) cases alongside point lookup, restructured into `ReadBenchmark` / `RangeBenchmark` / `CountBenchmark` over a shared `StoreBenchmarkBase`.
- Added an 8-thread parallel point-lookup benchmark to track refcount cache-line contention.

## README

- Replaced the stale benchmark table with light/dark-aware SVG charts (`docs/benchmarks/`), a new **Performance** section with raw BenchmarkDotNet tables, and fairness notes (SQLite configs, RocksDB binding overhead). Outlier bars are truncated with an axis-break glyph so the remaining bars stay readable.

| Case | DryDB | RocksDB | SQLite (prepared+immutable) | SQLite (default) |
|---|---:|---:|---:|---:|
| Point lookup (per query) | 29 ns | 241 ns | 943 ns | 6,656 ns |
| Range scan, 100 rows | 1.4 µs | 14.0 µs | 9.6 µs | 17.4 µs |
| Count, 8,000 rows | 15.2 µs | 982 µs | 117 µs | 108 µs |

All 71 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)