### PR TITLE
Fix cache-thrash livelock and speed up reads and counts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,6 @@ src/DryDB.Unity/Assets/Packages/*
 ### Internal Unity Packages in bin/Debug ###
 !src/DryDB/bin/Debug/netstandard2.1/package.json
 !src/DryDB.Compression/bin/Debug/netstandard2.1/package.json
+
+### BenchmarkDotNet output ###
+BenchmarkDotNet.Artifacts/

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ DryDB is a read-only embedded B+Tree based key/value database, implemented pure 
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="docs/benchmarks/point_lookup_dark.svg">
-  <img alt="Point lookup benchmark: DryDB 29 ns, RocksDB 241 ns, SQLite (prepared + immutable) 943 ns, SQLite (default) 6,656 ns per query" src="docs/benchmarks/point_lookup_light.svg">
+  <img alt="Point lookup benchmark: DryDB 25 ns, RocksDB 251 ns, SQLite (prepared + immutable) 655 ns, SQLite (default) 5,248 ns per query" src="docs/benchmarks/point_lookup_light.svg">
 </picture>
 
 See [Performance](#performance) for details.
@@ -57,42 +57,44 @@ Two SQLite configurations are shown to keep the comparison fair:
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="docs/benchmarks/point_lookup_dark.svg">
-  <img alt="Point lookup benchmark: DryDB 29 ns, RocksDB 241 ns, SQLite (prepared + immutable) 943 ns, SQLite (default) 6,656 ns per query" src="docs/benchmarks/point_lookup_light.svg">
+  <img alt="Point lookup benchmark: DryDB 25 ns, RocksDB 251 ns, SQLite (prepared + immutable) 655 ns, SQLite (default) 5,248 ns per query" src="docs/benchmarks/point_lookup_light.svg">
 </picture>
 
 ### Range scan
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="docs/benchmarks/range_scan_dark.svg">
-  <img alt="Range scan benchmark (100 rows): DryDB 1.4 µs, SQLite (prepared + immutable) 9.6 µs, RocksDB 14.0 µs, SQLite (default) 17.4 µs per query" src="docs/benchmarks/range_scan_light.svg">
+  <img alt="Range scan benchmark (100 rows): DryDB 1.2 µs, SQLite (prepared + immutable) 7.4 µs, RocksDB 11.7 µs, SQLite (default) 13.5 µs per query" src="docs/benchmarks/range_scan_light.svg">
 </picture>
 
 ### Count by key range
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="docs/benchmarks/count_range_dark.svg">
-  <img alt="Count benchmark (8,000 rows): DryDB 15.2 µs, SQLite (default) 108 µs, SQLite (prepared + immutable) 117 µs, RocksDB 982 µs per query" src="docs/benchmarks/count_range_light.svg">
+  <img alt="Count benchmark (8,000 rows): DryDB 1.2 µs, SQLite (prepared + immutable) 95 µs, SQLite (default) 102 µs, RocksDB 696 µs per query" src="docs/benchmarks/count_range_light.svg">
 </picture>
 
 <details>
 <summary>Raw BenchmarkDotNet results</summary>
 
-1 op = 1000 queries for point lookup, 100 queries for range scan and count.
+1 op = 1000 queries for point lookup, 100 queries for range scan and count. The `Parallel` variants run 8 threads of 1000 queries each: `ParallelSpread` reads spread-out keys (the realistic shape), `Parallel` hammers a single key (worst case for page refcount contention).
 
-| Type           | Method                   | Mean         | Error        | StdDev       | Allocated  |
-|--------------- |------------------------- |-------------:|-------------:|-------------:|-----------:|
-| ReadBenchmark  | DryDB_FindByKey          |     29.00 us |     2.133 us |     1.269 us |          - |
-| ReadBenchmark  | RocksDB_FindByKey        |    240.74 us |    42.123 us |    27.862 us |    40032 B |
-| ReadBenchmark  | CsSqlite_FindByKey_Fair  |    943.04 us |   152.115 us |   100.615 us |    48000 B |
-| ReadBenchmark  | CsSqlite_FindByKey       |  6,655.59 us |   557.215 us |   368.563 us |    48000 B |
-| RangeBenchmark | DryDB_GetRange           |    140.02 us |     6.377 us |     4.218 us |          - |
-| RangeBenchmark | CsSqlite_GetRange_Fair   |    958.48 us |   124.718 us |    82.493 us |   480000 B |
-| RangeBenchmark | RocksDB_GetRange         |  1,396.66 us |   157.288 us |   104.036 us |   726432 B |
-| RangeBenchmark | CsSqlite_GetRange        |  1,743.15 us |   218.851 us |   144.757 us |   480000 B |
-| CountBenchmark | DryDB_CountRange         |  1,524.56 us |   123.628 us |    81.772 us |          - |
-| CountBenchmark | CsSqlite_CountRange      | 10,796.05 us |   956.138 us |   632.426 us |          - |
-| CountBenchmark | CsSqlite_CountRange_Fair | 11,715.51 us |   926.636 us |   551.426 us |          - |
-| CountBenchmark | RocksDB_CountRange       | 98,221.60 us | 5,595.564 us | 3,701.119 us | 25606432 B |
+| Type           | Method                         | Mean         | Error      | StdDev     | Allocated  |
+|--------------- |------------------------------- |-------------:|-----------:|-----------:|-----------:|
+| ReadBenchmark  | DryDB_FindByKey                |     25.07 us |   0.532 us |   0.317 us |          - |
+| ReadBenchmark  | DryDB_FindByKey_ParallelSpread |    237.76 us |   9.713 us |   5.780 us |     1548 B |
+| ReadBenchmark  | DryDB_FindByKey_Parallel       |    773.89 us |  21.605 us |  11.300 us |     1295 B |
+| ReadBenchmark  | RocksDB_FindByKey              |    251.26 us |  10.410 us |   6.885 us |    40032 B |
+| ReadBenchmark  | CsSqlite_FindByKey_Fair        |    655.07 us |   7.097 us |   3.712 us |    48000 B |
+| ReadBenchmark  | CsSqlite_FindByKey             |  5,248.39 us | 226.384 us | 134.717 us |    48000 B |
+| RangeBenchmark | DryDB_GetRange                 |    118.00 us |   4.082 us |   2.429 us |          - |
+| RangeBenchmark | CsSqlite_GetRange_Fair         |    736.90 us |  26.714 us |  17.669 us |   480000 B |
+| RangeBenchmark | RocksDB_GetRange               |  1,165.22 us |  23.126 us |  13.762 us |   726432 B |
+| RangeBenchmark | CsSqlite_GetRange              |  1,353.17 us | 358.424 us | 237.075 us |   480000 B |
+| CountBenchmark | DryDB_CountRange               |    115.48 us |   4.205 us |   2.781 us |          - |
+| CountBenchmark | CsSqlite_CountRange_Fair       |  9,541.64 us | 245.306 us | 162.255 us |          - |
+| CountBenchmark | CsSqlite_CountRange            | 10,155.59 us | 558.465 us | 369.390 us |          - |
+| CountBenchmark | RocksDB_CountRange             | 69,559.70 us | 799.489 us | 475.763 us | 25606432 B |
 
 </details>
 

--- a/docs/benchmarks/count_range_dark.svg
+++ b/docs/benchmarks/count_range_dark.svg
@@ -5,18 +5,18 @@
     <text x="24" y="48" font-size="11.5" fill="#c3c2b7">Count 8,000 rows in a key range — time per query (lower is better)</text>
     <line x1="262" y1="58" x2="262" y2="203" stroke="#3a3936" stroke-width="1"/>
   <text x="250" y="75" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">DryDB</text>
-  <path d="M262 64 h43.45 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-43.45 Z" fill="#3987e5"/>
-  <text x="317.44704570791527" y="75" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">15.2 µs</text>
-  <text x="250" y="112" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">SQLite (CsSqlite, default)</text>
-  <path d="M262 101 h333.12 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-333.12 Z" fill="#8d8c82"/>
-  <text x="607.123745819398" y="112" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">108 µs</text>
-  <text x="250" y="149" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">SQLite (CsSqlite, prepared + immutable)</text>
+  <path d="M262 64 h2.15 a2.148337595907928 2.148337595907928 0 0 1 2.148337595907928 2.148337595907928 v17.703324808184142 a2.148337595907928 2.148337595907928 0 0 1 -2.148337595907928 2.148337595907928 h-2.15 Z" fill="#3987e5"/>
+  <text x="274.29667519181584" y="75" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">1.2 µs</text>
+  <text x="250" y="112" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">SQLite (CsSqlite, prepared + immutable)</text>
+  <path d="M262 101 h336.15 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-336.15 Z" fill="#8d8c82"/>
+  <text x="610.153452685422" y="112" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">95 µs</text>
+  <text x="250" y="149" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">SQLite (CsSqlite, default)</text>
   <path d="M262 138 h361.22 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-361.22 Z" fill="#8d8c82"/>
-  <text x="635.2173913043479" y="149" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">117 µs</text>
+  <text x="635.2173913043478" y="149" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">102 µs</text>
   <text x="250" y="186" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">RocksDB</text>
   <path d="M262 175 h416.00 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-416 Z" fill="#8d8c82"/>
   <path d="M606.4 173 l-6 26 h7 l6 -26 Z" fill="#1a1a19"/>
-  <text x="690" y="186" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">982 µs</text>
+  <text x="690" y="186" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">696 µs</text>
     <text x="24" y="230" font-size="10.5" fill="#8a897f">BenchmarkDotNet · .NET 10 · Apple M-series · 10,000 rows (int64 key, 13-byte value) · 4 KB pages</text>
   </g>
 </svg>

--- a/docs/benchmarks/count_range_light.svg
+++ b/docs/benchmarks/count_range_light.svg
@@ -5,18 +5,18 @@
     <text x="24" y="48" font-size="11.5" fill="#52514e">Count 8,000 rows in a key range — time per query (lower is better)</text>
     <line x1="262" y1="58" x2="262" y2="203" stroke="#d8d7d2" stroke-width="1"/>
   <text x="250" y="75" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">DryDB</text>
-  <path d="M262 64 h43.45 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-43.45 Z" fill="#2a78d6"/>
-  <text x="317.44704570791527" y="75" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">15.2 µs</text>
-  <text x="250" y="112" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">SQLite (CsSqlite, default)</text>
-  <path d="M262 101 h333.12 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-333.12 Z" fill="#7c7b74"/>
-  <text x="607.123745819398" y="112" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">108 µs</text>
-  <text x="250" y="149" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">SQLite (CsSqlite, prepared + immutable)</text>
+  <path d="M262 64 h2.15 a2.148337595907928 2.148337595907928 0 0 1 2.148337595907928 2.148337595907928 v17.703324808184142 a2.148337595907928 2.148337595907928 0 0 1 -2.148337595907928 2.148337595907928 h-2.15 Z" fill="#2a78d6"/>
+  <text x="274.29667519181584" y="75" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">1.2 µs</text>
+  <text x="250" y="112" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">SQLite (CsSqlite, prepared + immutable)</text>
+  <path d="M262 101 h336.15 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-336.15 Z" fill="#7c7b74"/>
+  <text x="610.153452685422" y="112" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">95 µs</text>
+  <text x="250" y="149" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">SQLite (CsSqlite, default)</text>
   <path d="M262 138 h361.22 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-361.22 Z" fill="#7c7b74"/>
-  <text x="635.2173913043479" y="149" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">117 µs</text>
+  <text x="635.2173913043478" y="149" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">102 µs</text>
   <text x="250" y="186" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">RocksDB</text>
   <path d="M262 175 h416.00 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-416 Z" fill="#7c7b74"/>
   <path d="M606.4 173 l-6 26 h7 l6 -26 Z" fill="#fcfcfb"/>
-  <text x="690" y="186" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">982 µs</text>
+  <text x="690" y="186" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">696 µs</text>
     <text x="24" y="230" font-size="10.5" fill="#8a897f">BenchmarkDotNet · .NET 10 · Apple M-series · 10,000 rows (int64 key, 13-byte value) · 4 KB pages</text>
   </g>
 </svg>

--- a/docs/benchmarks/point_lookup_dark.svg
+++ b/docs/benchmarks/point_lookup_dark.svg
@@ -5,18 +5,18 @@
     <text x="24" y="48" font-size="11.5" fill="#c3c2b7">Find one value by key, 10,000 rows — time per query (lower is better)</text>
     <line x1="262" y1="58" x2="262" y2="203" stroke="#3a3936" stroke-width="1"/>
   <text x="250" y="75" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">DryDB</text>
-  <path d="M262 64 h7.23 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-7.23 Z" fill="#3987e5"/>
-  <text x="281.2314998386279" y="75" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">29 ns</text>
+  <path d="M262 64 h9.94 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-9.94 Z" fill="#3987e5"/>
+  <text x="283.9395950879522" y="75" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">25 ns</text>
   <text x="250" y="112" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">RocksDB</text>
-  <path d="M262 101 h89.34 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-89.34 Z" fill="#8d8c82"/>
-  <text x="363.3376365899765" y="112" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">241 ns</text>
+  <path d="M262 101 h135.95 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-135.95 Z" fill="#8d8c82"/>
+  <text x="409.9535346830402" y="112" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">251 ns</text>
   <text x="250" y="149" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">SQLite (CsSqlite, prepared + immutable)</text>
   <path d="M262 138 h361.22 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-361.22 Z" fill="#8d8c82"/>
-  <text x="635.217391304348" y="149" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">943 ns</text>
+  <text x="635.2173913043479" y="149" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">655 ns</text>
   <text x="250" y="186" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">SQLite (CsSqlite, default)</text>
   <path d="M262 175 h416.00 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-416 Z" fill="#8d8c82"/>
   <path d="M606.4 173 l-6 26 h7 l6 -26 Z" fill="#1a1a19"/>
-  <text x="690" y="186" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">6,656 ns</text>
+  <text x="690" y="186" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">5,248 ns</text>
     <text x="24" y="230" font-size="10.5" fill="#8a897f">BenchmarkDotNet · .NET 10 · Apple M-series · 10,000 rows (int64 key, 13-byte value) · 4 KB pages</text>
   </g>
 </svg>

--- a/docs/benchmarks/point_lookup_light.svg
+++ b/docs/benchmarks/point_lookup_light.svg
@@ -5,18 +5,18 @@
     <text x="24" y="48" font-size="11.5" fill="#52514e">Find one value by key, 10,000 rows — time per query (lower is better)</text>
     <line x1="262" y1="58" x2="262" y2="203" stroke="#d8d7d2" stroke-width="1"/>
   <text x="250" y="75" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">DryDB</text>
-  <path d="M262 64 h7.23 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-7.23 Z" fill="#2a78d6"/>
-  <text x="281.2314998386279" y="75" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">29 ns</text>
+  <path d="M262 64 h9.94 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-9.94 Z" fill="#2a78d6"/>
+  <text x="283.9395950879522" y="75" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">25 ns</text>
   <text x="250" y="112" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">RocksDB</text>
-  <path d="M262 101 h89.34 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-89.34 Z" fill="#7c7b74"/>
-  <text x="363.3376365899765" y="112" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">241 ns</text>
+  <path d="M262 101 h135.95 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-135.95 Z" fill="#7c7b74"/>
+  <text x="409.9535346830402" y="112" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">251 ns</text>
   <text x="250" y="149" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">SQLite (CsSqlite, prepared + immutable)</text>
   <path d="M262 138 h361.22 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-361.22 Z" fill="#7c7b74"/>
-  <text x="635.217391304348" y="149" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">943 ns</text>
+  <text x="635.2173913043479" y="149" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">655 ns</text>
   <text x="250" y="186" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">SQLite (CsSqlite, default)</text>
   <path d="M262 175 h416.00 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-416 Z" fill="#7c7b74"/>
   <path d="M606.4 173 l-6 26 h7 l6 -26 Z" fill="#fcfcfb"/>
-  <text x="690" y="186" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">6,656 ns</text>
+  <text x="690" y="186" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">5,248 ns</text>
     <text x="24" y="230" font-size="10.5" fill="#8a897f">BenchmarkDotNet · .NET 10 · Apple M-series · 10,000 rows (int64 key, 13-byte value) · 4 KB pages</text>
   </g>
 </svg>

--- a/docs/benchmarks/range_scan_dark.svg
+++ b/docs/benchmarks/range_scan_dark.svg
@@ -5,17 +5,17 @@
     <text x="24" y="48" font-size="11.5" fill="#c3c2b7">Read 100 consecutive rows by key range — time per query (lower is better)</text>
     <line x1="262" y1="58" x2="262" y2="203" stroke="#3a3936" stroke-width="1"/>
   <text x="250" y="75" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">DryDB</text>
-  <path d="M262 64 h25.39 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-25.39 Z" fill="#3987e5"/>
-  <text x="299.38530734632684" y="75" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">1.4 µs</text>
+  <path d="M262 64 h28.46 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-28.46 Z" fill="#3987e5"/>
+  <text x="302.463768115942" y="75" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">1.2 µs</text>
   <text x="250" y="112" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">SQLite (CsSqlite, prepared + immutable)</text>
-  <path d="M262 101 h197.50 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-197.5 Z" fill="#8d8c82"/>
-  <text x="471.4992503748126" y="112" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">9.6 µs</text>
+  <path d="M262 101 h196.19 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-196.19 Z" fill="#8d8c82"/>
+  <text x="470.1932367149759" y="112" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">7.4 µs</text>
   <text x="250" y="149" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">RocksDB</text>
-  <path d="M262 138 h289.85 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-289.85 Z" fill="#8d8c82"/>
-  <text x="563.8530734632684" y="149" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">14 µs</text>
+  <path d="M262 138 h312.52 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-312.52 Z" fill="#8d8c82"/>
+  <text x="586.5217391304348" y="149" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">11.7 µs</text>
   <text x="250" y="186" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">SQLite (CsSqlite, default)</text>
   <path d="M262 175 h361.22 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-361.22 Z" fill="#8d8c82"/>
-  <text x="635.2173913043478" y="186" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">17.4 µs</text>
+  <text x="635.2173913043479" y="186" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">13.5 µs</text>
     <text x="24" y="230" font-size="10.5" fill="#8a897f">BenchmarkDotNet · .NET 10 · Apple M-series · 10,000 rows (int64 key, 13-byte value) · 4 KB pages</text>
   </g>
 </svg>

--- a/docs/benchmarks/range_scan_light.svg
+++ b/docs/benchmarks/range_scan_light.svg
@@ -5,17 +5,17 @@
     <text x="24" y="48" font-size="11.5" fill="#52514e">Read 100 consecutive rows by key range — time per query (lower is better)</text>
     <line x1="262" y1="58" x2="262" y2="203" stroke="#d8d7d2" stroke-width="1"/>
   <text x="250" y="75" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">DryDB</text>
-  <path d="M262 64 h25.39 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-25.39 Z" fill="#2a78d6"/>
-  <text x="299.38530734632684" y="75" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">1.4 µs</text>
+  <path d="M262 64 h28.46 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-28.46 Z" fill="#2a78d6"/>
+  <text x="302.463768115942" y="75" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">1.2 µs</text>
   <text x="250" y="112" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">SQLite (CsSqlite, prepared + immutable)</text>
-  <path d="M262 101 h197.50 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-197.5 Z" fill="#7c7b74"/>
-  <text x="471.4992503748126" y="112" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">9.6 µs</text>
+  <path d="M262 101 h196.19 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-196.19 Z" fill="#7c7b74"/>
+  <text x="470.1932367149759" y="112" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">7.4 µs</text>
   <text x="250" y="149" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">RocksDB</text>
-  <path d="M262 138 h289.85 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-289.85 Z" fill="#7c7b74"/>
-  <text x="563.8530734632684" y="149" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">14 µs</text>
+  <path d="M262 138 h312.52 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-312.52 Z" fill="#7c7b74"/>
+  <text x="586.5217391304348" y="149" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">11.7 µs</text>
   <text x="250" y="186" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">SQLite (CsSqlite, default)</text>
   <path d="M262 175 h361.22 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-361.22 Z" fill="#7c7b74"/>
-  <text x="635.2173913043478" y="186" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">17.4 µs</text>
+  <text x="635.2173913043479" y="186" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">13.5 µs</text>
     <text x="24" y="230" font-size="10.5" fill="#8a897f">BenchmarkDotNet · .NET 10 · Apple M-series · 10,000 rows (int64 key, 13-byte value) · 4 KB pages</text>
   </g>
 </svg>

--- a/sandbox/DryDB.Benchmark/ReadBenchmark.cs
+++ b/sandbox/DryDB.Benchmark/ReadBenchmark.cs
@@ -53,33 +53,30 @@ public class ReadBenchmark : StoreBenchmarkBase
         Task.WaitAll(tasks);
     }
 
-    [Benchmark]
-    public void DryDB_FindByKey_RefCounted()
-    {
-        for (var i = 0; i < Iterations; i++)
-        {
-            var table = databaseRefCounted.GetTable("items");
-            using var _ = table.Get(FindKey);
-        }
-    }
 
+
+    // Parallel reads over spread-out keys: no single hot cache line, which is the
+    // realistic shape of concurrent workloads (the same-key variants above are the
+    // worst case for refcount line contention).
     [Benchmark]
-    public void DryDB_FindByKey_Parallel_RefCounted()
+    public void DryDB_FindByKey_ParallelSpread()
     {
         var tasks = new Task[ThreadCount];
         for (var t = 0; t < ThreadCount; t++)
         {
+            var offset = t * 1000;
             tasks[t] = Task.Run(() =>
             {
-                var table = databaseRefCounted.GetTable("items");
+                var table = database.GetTable("items");
                 for (var i = 0; i < Iterations; i++)
                 {
-                    using var _ = table.Get(FindKey);
+                    using var _ = table.Get((offset + i * 7) % N);
                 }
             });
         }
         Task.WaitAll(tasks);
     }
+
 
     [Benchmark]
     public void CsSqlite_FindByKey()

--- a/sandbox/DryDB.Benchmark/ReadBenchmark.cs
+++ b/sandbox/DryDB.Benchmark/ReadBenchmark.cs
@@ -54,6 +54,34 @@ public class ReadBenchmark : StoreBenchmarkBase
     }
 
     [Benchmark]
+    public void DryDB_FindByKey_RefCounted()
+    {
+        for (var i = 0; i < Iterations; i++)
+        {
+            var table = databaseRefCounted.GetTable("items");
+            using var _ = table.Get(FindKey);
+        }
+    }
+
+    [Benchmark]
+    public void DryDB_FindByKey_Parallel_RefCounted()
+    {
+        var tasks = new Task[ThreadCount];
+        for (var t = 0; t < ThreadCount; t++)
+        {
+            tasks[t] = Task.Run(() =>
+            {
+                var table = databaseRefCounted.GetTable("items");
+                for (var i = 0; i < Iterations; i++)
+                {
+                    using var _ = table.Get(FindKey);
+                }
+            });
+        }
+        Task.WaitAll(tasks);
+    }
+
+    [Benchmark]
     public void CsSqlite_FindByKey()
     {
         for (var i = 0; i < Iterations; i++)

--- a/sandbox/DryDB.Benchmark/StoreBenchmarkBase.cs
+++ b/sandbox/DryDB.Benchmark/StoreBenchmarkBase.cs
@@ -29,7 +29,6 @@ public abstract class StoreBenchmarkBase
     protected const int N = 10000;
 
     protected ReadOnlyDatabase database = default!;
-    protected ReadOnlyDatabase databaseRefCounted = default!;
 
     // sqlite: as-is defaults (command prepared per query)
     protected SqliteConnection cssqliteConnection = default!;
@@ -108,11 +107,6 @@ public abstract class StoreBenchmarkBase
         {
         });
 
-        databaseRefCounted = await ReadOnlyDatabase.OpenFileAsync(drydbPath, new DatabaseLoadOptions
-        {
-            PageReclamation = PageReclamation.ReferenceCounted,
-        });
-
         cssqliteConnection = new SqliteConnection(sqlitePath);
         cssqliteImmutableConnection = new SqliteConnection($"file:{sqlitePath}?immutable=1");
         rocksDb = RocksDb.OpenReadOnly(rocksDbOptions, rocksdbPath, false);
@@ -129,7 +123,6 @@ public abstract class StoreBenchmarkBase
         cssqliteImmutableConnection.Dispose();
         rocksDb.Dispose();
         database.Dispose();
-        databaseRefCounted.Dispose();
 
         try
         {

--- a/sandbox/DryDB.Benchmark/StoreBenchmarkBase.cs
+++ b/sandbox/DryDB.Benchmark/StoreBenchmarkBase.cs
@@ -29,6 +29,7 @@ public abstract class StoreBenchmarkBase
     protected const int N = 10000;
 
     protected ReadOnlyDatabase database = default!;
+    protected ReadOnlyDatabase databaseRefCounted = default!;
 
     // sqlite: as-is defaults (command prepared per query)
     protected SqliteConnection cssqliteConnection = default!;
@@ -107,6 +108,11 @@ public abstract class StoreBenchmarkBase
         {
         });
 
+        databaseRefCounted = await ReadOnlyDatabase.OpenFileAsync(drydbPath, new DatabaseLoadOptions
+        {
+            PageReclamation = PageReclamation.ReferenceCounted,
+        });
+
         cssqliteConnection = new SqliteConnection(sqlitePath);
         cssqliteImmutableConnection = new SqliteConnection($"file:{sqlitePath}?immutable=1");
         rocksDb = RocksDb.OpenReadOnly(rocksDbOptions, rocksdbPath, false);
@@ -123,6 +129,7 @@ public abstract class StoreBenchmarkBase
         cssqliteImmutableConnection.Dispose();
         rocksDb.Dispose();
         database.Dispose();
+        databaseRefCounted.Dispose();
 
         try
         {

--- a/src/DryDB/BTree/TreeWalker.cs
+++ b/src/DryDB/BTree/TreeWalker.cs
@@ -354,22 +354,25 @@ class TreeWalker
                 }
 
                 var leafNode = new LeafNodeReader(pageSpan, header.EntryCount);
-                while (entryIndex < header.EntryCount)
+
+                // Entries within a leaf are sorted: locate the end bound with one binary
+                // search instead of comparing every entry.
+                var stopIndex = header.EntryCount;
+                var endsInThisLeaf = false;
+                if (!endKey.IsEmpty)
+                {
+                    var op = endKeyExclusive ? SearchOperator.LowerBound : SearchOperator.UpperBound;
+                    if (leafNode.TrySearch(endKey, op, comparer, out var boundIndex))
+                    {
+                        stopIndex = boundIndex;
+                        endsInThisLeaf = true;
+                    }
+                }
+
+                while (entryIndex < stopIndex)
                 {
                     leafNode.GetAt(entryIndex, out var pageOffset, out var keyLength, out var valueLength);
 
-                    // check end key
-                    if (!endKey.IsEmpty)
-                    {
-                        var key = MemoryMarshal.CreateReadOnlySpan(
-                            ref Unsafe.Add(ref MemoryMarshal.GetReference(pageSpan), pageOffset),
-                            keyLength);
-                        var compared = KeyCompare.Compare(comparer, key, endKey);
-                        if (compared > 0 || (endKeyExclusive && compared == 0))
-                        {
-                            return result;
-                        }
-                    }
                     if (LeafNodeReader.IsOverflow(valueLength))
                     {
                         var resolved = ResolveValue(currentPage, pageOffset + keyLength, valueLength);
@@ -384,7 +387,7 @@ class TreeWalker
                 }
 
                 // next node
-                if (header.RightSiblingPageNumber.IsEmpty)
+                if (endsInThisLeaf || header.RightSiblingPageNumber.IsEmpty)
                 {
                     return result;
                 }
@@ -428,22 +431,24 @@ class TreeWalker
                 }
 
                 var leafNode = new LeafNodeReader(pageSpan, header.EntryCount);
-                while (entryIndex >= 0)
+
+                // Entries within a leaf are sorted: locate the start bound with one
+                // binary search instead of comparing every entry.
+                var boundIndex = 0;
+                if (!startKey.IsEmpty)
+                {
+                    var op = startKeyExclusive ? SearchOperator.UpperBound : SearchOperator.LowerBound;
+                    if (!leafNode.TrySearch(startKey, op, comparer, out boundIndex))
+                    {
+                        // Everything in (and left of) this leaf is below the start bound.
+                        return result;
+                    }
+                }
+
+                while (entryIndex >= boundIndex)
                 {
                     leafNode.GetAt(entryIndex, out var pageOffset, out var keyLength, out var valueLength);
 
-                    // check start key (lower bound for descending)
-                    if (!startKey.IsEmpty)
-                    {
-                        var key = MemoryMarshal.CreateReadOnlySpan(
-                            ref Unsafe.Add(ref MemoryMarshal.GetReference(pageSpan), pageOffset),
-                            keyLength);
-                        var compared = KeyCompare.Compare(comparer, key, startKey);
-                        if (compared < 0 || (startKeyExclusive && compared == 0))
-                        {
-                            return result;
-                        }
-                    }
                     if (LeafNodeReader.IsOverflow(valueLength))
                     {
                         var resolved = ResolveValue(currentPage, pageOffset + keyLength, valueLength);
@@ -458,7 +463,7 @@ class TreeWalker
                 }
 
                 // previous node (left sibling)
-                if (header.LeftSiblingPageNumber.IsEmpty)
+                if (boundIndex > 0 || header.LeftSiblingPageNumber.IsEmpty)
                 {
                     return result;
                 }
@@ -535,25 +540,28 @@ class TreeWalker
                     throw new InvalidOperationException("Invalid node kind");
                 }
 
-                while (entryIndex < header.EntryCount)
+                // Entries within a leaf are sorted: locate the end bound with one binary
+                // search instead of comparing every entry.
+                var stopIndex = header.EntryCount;
+                var endsInThisLeaf = false;
+                if (!endKey.IsEmpty)
+                {
+                    var op = endKeyExclusive ? SearchOperator.LowerBound : SearchOperator.UpperBound;
+                    if (new LeafNodeReader(currentPage.Memory.Span, header.EntryCount)
+                        .TrySearch(endKey.Span, op, comparer, out var boundIndex))
+                    {
+                        stopIndex = boundIndex;
+                        endsInThisLeaf = true;
+                    }
+                }
+
+                while (entryIndex < stopIndex)
                 {
                     int pageOffset;
                     ushort keyLength, valueLength;
                     new LeafNodeReader(currentPage.Memory.Span, header.EntryCount)
                         .GetAt(entryIndex, out pageOffset, out keyLength, out valueLength);
 
-                    // check end key
-                    if (!endKey.IsEmpty)
-                    {
-                        var compared = KeyCompare.Compare(
-                            comparer,
-                            currentPage.Memory.Span.Slice(pageOffset, keyLength),
-                            endKey.Span);
-                        if (compared > 0 || (endKeyExclusive && compared == 0))
-                        {
-                            return result;
-                        }
-                    }
                     if (LeafNodeReader.IsOverflow(valueLength))
                     {
                         var resolved = await ResolveValueAsync(currentPage, pageOffset + keyLength, valueLength, cancellationToken)
@@ -570,7 +578,7 @@ class TreeWalker
                 }
 
                 // next node
-                if (header.RightSiblingPageNumber.IsEmpty)
+                if (endsInThisLeaf || header.RightSiblingPageNumber.IsEmpty)
                 {
                     return result;
                 }
@@ -614,25 +622,27 @@ class TreeWalker
                     throw new InvalidOperationException("Invalid node kind");
                 }
 
-                while (entryIndex >= 0)
+                // Entries within a leaf are sorted: locate the start bound with one
+                // binary search instead of comparing every entry.
+                var boundIndex = 0;
+                if (!startKey.IsEmpty)
+                {
+                    var op = startKeyExclusive ? SearchOperator.UpperBound : SearchOperator.LowerBound;
+                    if (!new LeafNodeReader(currentPage.Memory.Span, header.EntryCount)
+                        .TrySearch(startKey.Span, op, comparer, out boundIndex))
+                    {
+                        // Everything in (and left of) this leaf is below the start bound.
+                        return result;
+                    }
+                }
+
+                while (entryIndex >= boundIndex)
                 {
                     int pageOffset;
                     ushort keyLength, valueLength;
                     new LeafNodeReader(currentPage.Memory.Span, header.EntryCount)
                         .GetAt(entryIndex, out pageOffset, out keyLength, out valueLength);
 
-                    // check start key (lower bound for descending)
-                    if (!startKey.IsEmpty)
-                    {
-                        var compared = KeyCompare.Compare(
-                            comparer,
-                            currentPage.Memory.Span.Slice(pageOffset, keyLength),
-                            startKey.Span);
-                        if (compared < 0 || (startKeyExclusive && compared == 0))
-                        {
-                            return result;
-                        }
-                    }
                     if (LeafNodeReader.IsOverflow(valueLength))
                     {
                         var resolved = await ResolveValueAsync(currentPage, pageOffset + keyLength, valueLength, cancellationToken)
@@ -649,7 +659,7 @@ class TreeWalker
                 }
 
                 // previous node (left sibling)
-                if (header.LeftSiblingPageNumber.IsEmpty)
+                if (boundIndex > 0 || header.LeftSiblingPageNumber.IsEmpty)
                 {
                     return result;
                 }
@@ -713,31 +723,19 @@ class TreeWalker
                     throw new InvalidOperationException("Invalid node kind");
                 }
 
-                var leafNode = new LeafNodeReader(pageSpan, header.EntryCount);
-                while (entryIndex < header.EntryCount)
+                // Entries within a leaf are sorted: locate the end bound with one binary
+                // search instead of comparing every entry.
+                if (!endKey.IsEmpty)
                 {
-                    leafNode.GetAt(
-                        entryIndex,
-                        out var pageOffset,
-                        out var keyLength,
-                        out _);
-
-                    // check end key
-                    if (!endKey.IsEmpty)
+                    var leafNode = new LeafNodeReader(pageSpan, header.EntryCount);
+                    var op = endKeyExclusive ? SearchOperator.LowerBound : SearchOperator.UpperBound;
+                    if (leafNode.TrySearch(endKey, op, comparer, out var boundIndex))
                     {
-                        var key = MemoryMarshal.CreateReadOnlySpan(
-                            ref Unsafe.Add(ref MemoryMarshal.GetReference(pageSpan), pageOffset),
-                            keyLength);
-                        var compared = KeyCompare.Compare(comparer, key, endKey);
-                        if (compared > 0 || (endKeyExclusive && compared == 0))
-                        {
-                            return count;
-                        }
+                        // The range ends inside this leaf.
+                        return count + Math.Max(0, boundIndex - entryIndex);
                     }
-
-                    count++;
-                    entryIndex++;
                 }
+                count += header.EntryCount - entryIndex;
 
                 // next node
                 if (header.RightSiblingPageNumber.IsEmpty)
@@ -808,31 +806,19 @@ class TreeWalker
                     throw new InvalidOperationException("Invalid node kind");
                 }
 
-                var leafNode = new LeafNodeReader(pageSpan, header.EntryCount);
-                while (entryIndex < header.EntryCount)
+                // Entries within a leaf are sorted: locate the end bound with one binary
+                // search instead of comparing every entry.
+                if (!endKey.IsEmpty)
                 {
-                    leafNode.GetAt(
-                        entryIndex,
-                        out var pageOffset,
-                        out var keyLength,
-                        out _);
-
-                    // check end key
-                    if (!endKey.IsEmpty)
+                    var leafNode = new LeafNodeReader(pageSpan, header.EntryCount);
+                    var op = endKeyExclusive ? SearchOperator.LowerBound : SearchOperator.UpperBound;
+                    if (leafNode.TrySearch(endKey.Span, op, comparer, out var boundIndex))
                     {
-                        var key = MemoryMarshal.CreateReadOnlySpan(
-                            ref Unsafe.Add(ref MemoryMarshal.GetReference(pageSpan), pageOffset),
-                            keyLength);
-                        var compared = KeyCompare.Compare(comparer, key, endKey.Span);
-                        if (compared > 0 || (endKeyExclusive && compared == 0))
-                        {
-                            return count;
-                        }
+                        // The range ends inside this leaf.
+                        return count + Math.Max(0, boundIndex - entryIndex);
                     }
-
-                    count++;
-                    entryIndex++;
                 }
+                count += header.EntryCount - entryIndex;
 
                 // next node
                 if (header.RightSiblingPageNumber.IsEmpty)

--- a/src/DryDB/BTree/TreeWalker.cs
+++ b/src/DryDB/BTree/TreeWalker.cs
@@ -23,11 +23,38 @@ class TreeWalker
     readonly IKeyEncoding comparer;
 
     // The root page is touched by every lookup. Keep one retained reference here so the
-    // hot path can skip the cache lookup + refcount traffic for it. The pin lives for the
-    // lifetime of the TreeWalker; the underlying buffer is reclaimed by the GC afterwards.
+    // hot path can skip the cache lookup + refcount traffic for it. The pin lives until
+    // the owning database is disposed (see ReleasePinnedRoot).
     IPageEntry? pinnedRoot;
 
     static readonly int BlobDataOffset = Unsafe.SizeOf<PageHeader>() + Unsafe.SizeOf<NodeHeader>();
+
+    /// <summary>
+    /// A page acquired for a tree walk. <see cref="Owned"/> is false when the page is
+    /// served from the pinned root, in which case the walk holds no reference of its
+    /// own and must not release it (use <see cref="Take"/> to hand the page out).
+    /// </summary>
+    readonly struct PageLease(IPageEntry page, bool owned)
+    {
+        public IPageEntry Page => page;
+        public bool Owned => owned;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Release()
+        {
+            if (owned) page.Release();
+        }
+
+        /// <summary>
+        /// Take a caller-owned reference to the page (for handing it out beyond the walk).
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public IPageEntry Take()
+        {
+            if (!owned) page.Retain();
+            return page;
+        }
+    }
 
     internal TreeWalker(
         PageNumber rootPageNumber,
@@ -47,43 +74,227 @@ class TreeWalker
         };
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public SingleValueResult Get(ReadOnlySpan<byte> key)
+    /// <summary>
+    /// Drop the pinned root reference. Required for page buffers over unmanaged memory
+    /// (e.g. the Unity NativeArray loader), which are only freed when their refcount
+    /// reaches zero.
+    /// </summary>
+    internal void ReleasePinnedRoot()
     {
-        PageNumber? next = RootPageNumber;
-        PageSlice pageSlice;
+        var root = Interlocked.Exchange(ref pinnedRoot, null);
+        root?.Release();
+    }
 
-        while (!TryFindFrom(next.Value, key, out _, out pageSlice, out next))
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    PageLease GetPage(PageNumber pageNumber)
+    {
+        if (pageNumber == RootPageNumber)
         {
-            if (!next.HasValue) return SingleValueResult.Empty;
-            PageCache.Load(next.Value);
+            var root = pinnedRoot;
+            if (root != null)
+            {
+                return new PageLease(root, false);
+            }
+            return PinRoot(PageCache.GetOrLoad(pageNumber));
+        }
+        return new PageLease(PageCache.GetOrLoad(pageNumber), true);
+    }
+
+    ValueTask<PageLease> GetPageAsync(PageNumber pageNumber, CancellationToken cancellationToken)
+    {
+        if (pageNumber == RootPageNumber)
+        {
+            var root = pinnedRoot;
+            if (root != null)
+            {
+                return new ValueTask<PageLease>(new PageLease(root, false));
+            }
+            return PinRootAsync(pageNumber, cancellationToken);
+        }
+        return GetOwnedAsync(pageNumber, cancellationToken);
+
+        async ValueTask<PageLease> PinRootAsync(PageNumber rootPageNumber, CancellationToken ct)
+        {
+            var page = await PageCache.GetOrLoadAsync(rootPageNumber, ct).ConfigureAwait(false);
+            return PinRoot(page);
         }
 
-        return new SingleValueResult(pageSlice, true);
+        async ValueTask<PageLease> GetOwnedAsync(PageNumber pn, CancellationToken ct)
+        {
+            return new PageLease(await PageCache.GetOrLoadAsync(pn, ct).ConfigureAwait(false), true);
+        }
+    }
+
+    PageLease PinRoot(IPageEntry page)
+    {
+        // Transfer the freshly acquired reference to the pin. If another thread won the
+        // race, keep using our own reference as a normal owned lease.
+        if (Interlocked.CompareExchange(ref pinnedRoot, page, null) == null)
+        {
+            return new PageLease(page, false);
+        }
+        return new PageLease(page, true);
+    }
+
+    public SingleValueResult Get(ReadOnlySpan<byte> key)
+    {
+        var pageNumber = RootPageNumber;
+        while (true)
+        {
+            var lease = GetPage(pageNumber);
+            var pageSpan = lease.Page.Memory.Span;
+            var header = NodeHeader.Parse(pageSpan);
+            if (header.Kind == NodeKind.Internal)
+            {
+                var internalNode = new InternalNodeReader(pageSpan, header.EntryCount);
+                var descended = internalNode.TrySearch(key, comparer, out pageNumber);
+                lease.Release();
+                if (!descended)
+                {
+                    return SingleValueResult.Empty;
+                }
+            }
+            else // Leaf
+            {
+                var leafNode = new LeafNodeReader(pageSpan, header.EntryCount);
+                if (leafNode.TryFindValue(key, comparer, out _, out var valueOffset, out var valueLength))
+                {
+                    if (LeafNodeReader.IsOverflow(valueLength))
+                    {
+                        var resolved = ResolveValue(lease.Page, valueOffset, valueLength);
+                        lease.Release();
+                        return new SingleValueResult(resolved, true);
+                    }
+                    return new SingleValueResult(new PageSlice(lease.Take(), valueOffset, valueLength), true);
+                }
+
+                lease.Release();
+                return SingleValueResult.Empty;
+            }
+        }
     }
 
     public async ValueTask<SingleValueResult> GetAsync(
         ReadOnlyMemory<byte> key,
         CancellationToken cancellationToken = default)
     {
-        PageSlice resultValue;
-        PageNumber? next = RootPageNumber;
-
-        while (!TryFindFrom(next.Value, key.Span, out _, out resultValue, out next))
+        var pageNumber = RootPageNumber;
+        while (true)
         {
-            if (!next.HasValue)
+            var lease = await GetPageAsync(pageNumber, cancellationToken).ConfigureAwait(false);
+            var header = NodeHeader.Parse(lease.Page.Memory.Span);
+            if (header.Kind == NodeKind.Internal)
             {
+                var descended = new InternalNodeReader(lease.Page.Memory.Span, header.EntryCount)
+                    .TrySearch(key.Span, comparer, out pageNumber);
+                lease.Release();
+                if (!descended)
+                {
+                    return SingleValueResult.Empty;
+                }
+            }
+            else // Leaf
+            {
+                if (new LeafNodeReader(lease.Page.Memory.Span, header.EntryCount)
+                    .TryFindValue(key.Span, comparer, out _, out var valueOffset, out var valueLength))
+                {
+                    if (LeafNodeReader.IsOverflow(valueLength))
+                    {
+                        var resolved = await ResolveValueAsync(lease.Page, valueOffset, valueLength, cancellationToken)
+                            .ConfigureAwait(false);
+                        lease.Release();
+                        return new SingleValueResult(resolved, true);
+                    }
+                    return new SingleValueResult(new PageSlice(lease.Take(), valueOffset, valueLength), true);
+                }
+
+                lease.Release();
                 return SingleValueResult.Empty;
             }
-
-            await PageCache.LoadAsync(next.Value, cancellationToken).ConfigureAwait(false);
         }
-
-        return new SingleValueResult(resultValue, true);
     }
 
     public RangeIterator CreateIterator(IteratorDirection iteratorDirection = IteratorDirection.Forward) =>
         new(this, iteratorDirection);
+
+    /// <summary>
+    /// Descend to the leaf that satisfies <paramref name="op"/> for the key. On success
+    /// the returned page carries a caller-owned reference.
+    /// </summary>
+    internal bool Search(
+        scoped ReadOnlySpan<byte> key,
+        SearchOperator op,
+        out IPageEntry page,
+        out int index)
+    {
+        var pageNumber = RootPageNumber;
+        while (true)
+        {
+            var lease = GetPage(pageNumber);
+            var pageSpan = lease.Page.Memory.Span;
+            var header = NodeHeader.Parse(pageSpan);
+            if (header.Kind == NodeKind.Internal)
+            {
+                var internalNode = new InternalNodeReader(pageSpan, header.EntryCount);
+                var descended = internalNode.TrySearch(key, comparer, out pageNumber);
+                lease.Release();
+                if (!descended)
+                {
+                    page = null!;
+                    index = default;
+                    return false;
+                }
+            }
+            else // Leaf
+            {
+                var leafNode = new LeafNodeReader(pageSpan, header.EntryCount);
+                if (leafNode.TrySearch(key, op, comparer, out index))
+                {
+                    page = lease.Take();
+                    return true;
+                }
+
+                lease.Release();
+                page = null!;
+                index = default;
+                return false;
+            }
+        }
+    }
+
+    internal async ValueTask<(IPageEntry? Page, int Index)> SearchAsync(
+        ReadOnlyMemory<byte> key,
+        SearchOperator op,
+        CancellationToken cancellationToken)
+    {
+        var pageNumber = RootPageNumber;
+        while (true)
+        {
+            var lease = await GetPageAsync(pageNumber, cancellationToken).ConfigureAwait(false);
+            var header = NodeHeader.Parse(lease.Page.Memory.Span);
+            if (header.Kind == NodeKind.Internal)
+            {
+                var descended = new InternalNodeReader(lease.Page.Memory.Span, header.EntryCount)
+                    .TrySearch(key.Span, comparer, out pageNumber);
+                lease.Release();
+                if (!descended)
+                {
+                    return (null, default);
+                }
+            }
+            else // Leaf
+            {
+                if (new LeafNodeReader(lease.Page.Memory.Span, header.EntryCount)
+                    .TrySearch(key.Span, op, comparer, out var index))
+                {
+                    return (lease.Take(), index);
+                }
+
+                lease.Release();
+                return (null, default);
+            }
+        }
+    }
 
     public RangeResult GetRange(
         ReadOnlySpan<byte> startKey,
@@ -111,29 +322,21 @@ class TreeWalker
         // find start position
         if (startKey.IsEmpty)
         {
-            var minValue = GetMinValue();
-            if (!minValue.HasValue)
+            var minLeaf = GetMinLeaf();
+            if (!minLeaf.HasValue)
             {
                 return RangeResult.Empty;
             }
-            page = minValue.Value.Page;
+            page = minLeaf.Value.Page;
             entryIndex = 0;
         }
-        else
+        else if (!Search(
+                     startKey,
+                     startKeyExclusive ? SearchOperator.UpperBound : SearchOperator.LowerBound,
+                     out page,
+                     out entryIndex))
         {
-            PageNumber? nextPageNumber = RootPageNumber;
-            while (!TrySearch(
-                       nextPageNumber.Value,
-                       startKey,
-                       startKeyExclusive ? SearchOperator.UpperBound : SearchOperator.LowerBound,
-                       out page,
-                       out entryIndex,
-                       out nextPageNumber))
-            {
-                if (!nextPageNumber.HasValue) return RangeResult.Empty;
-
-                PageCache.Load(nextPageNumber.Value);
-            }
+            return RangeResult.Empty;
         }
 
         var result = RangeResult.Rent();
@@ -186,11 +389,7 @@ class TreeWalker
                     return result;
                 }
 
-                var pageNumber = header.RightSiblingPageNumber;
-                while (!PageCache.TryGet(pageNumber, out page))
-                {
-                    PageCache.Load(pageNumber);
-                }
+                page = PageCache.GetOrLoad(header.RightSiblingPageNumber);
                 entryIndex = 0;
             }
             finally
@@ -264,13 +463,8 @@ class TreeWalker
                     return result;
                 }
 
-                var pageNumber = header.LeftSiblingPageNumber;
-                while (!PageCache.TryGet(pageNumber, out page))
-                {
-                    PageCache.Load(pageNumber);
-                }
-                var nextHeader = NodeHeader.Parse(page.Memory.Span);
-                entryIndex = nextHeader.EntryCount - 1;
+                page = PageCache.GetOrLoad(header.LeftSiblingPageNumber);
+                entryIndex = NodeHeader.Parse(page.Memory.Span).EntryCount - 1;
             }
             finally
             {
@@ -307,28 +501,25 @@ class TreeWalker
         // find start position
         if (startKey.IsEmpty)
         {
-            var minValue = GetMinValue();
-            if (!minValue.HasValue)
+            var minLeaf = GetMinLeaf();
+            if (!minLeaf.HasValue)
             {
                 return RangeResult.Empty;
             }
-            page = minValue.Value.Page;
+            page = minLeaf.Value.Page;
             entryIndex = 0;
         }
         else
         {
-            PageNumber? nextPageNumber = RootPageNumber;
-            while (!TrySearch(
-                       nextPageNumber.Value,
-                       startKey.Span,
-                       startKeyExclusive ? SearchOperator.UpperBound : SearchOperator.LowerBound,
-                       out page,
-                       out entryIndex,
-                       out nextPageNumber))
+            (var startPage, entryIndex) = await SearchAsync(
+                startKey,
+                startKeyExclusive ? SearchOperator.UpperBound : SearchOperator.LowerBound,
+                cancellationToken).ConfigureAwait(false);
+            if (startPage == null)
             {
-                if (!nextPageNumber.HasValue) return RangeResult.Empty;
-                await PageCache.LoadAsync(nextPageNumber.Value, cancellationToken).ConfigureAwait(false);
+                return RangeResult.Empty;
             }
+            page = startPage;
         }
 
         var result = RangeResult.Rent();
@@ -384,11 +575,8 @@ class TreeWalker
                     return result;
                 }
 
-                var pageNumber = header.RightSiblingPageNumber;
-                while (!PageCache.TryGet(pageNumber, out page))
-                {
-                    await PageCache.LoadAsync(pageNumber, cancellationToken).ConfigureAwait(false);
-                }
+                page = await PageCache.GetOrLoadAsync(header.RightSiblingPageNumber, cancellationToken)
+                    .ConfigureAwait(false);
                 entryIndex = 0;
             }
             finally
@@ -466,13 +654,9 @@ class TreeWalker
                     return result;
                 }
 
-                var pageNumber = header.LeftSiblingPageNumber;
-                while (!PageCache.TryGet(pageNumber, out page))
-                {
-                    await PageCache.LoadAsync(pageNumber, cancellationToken).ConfigureAwait(false);
-                }
-                var nextHeader = NodeHeader.Parse(page.Memory.Span);
-                entryIndex = nextHeader.EntryCount - 1;
+                page = await PageCache.GetOrLoadAsync(header.LeftSiblingPageNumber, cancellationToken)
+                    .ConfigureAwait(false);
+                entryIndex = NodeHeader.Parse(page.Memory.Span).EntryCount - 1;
             }
             finally
             {
@@ -489,35 +673,27 @@ class TreeWalker
     {
         ValidateRange(startKey, endKey);
 
+        int entryIndex;
         IPageEntry page;
 
-        int entryIndex;
         // find start position
         if (startKey.IsEmpty)
         {
-            var minValue = GetMinValue();
-            if (!minValue.HasValue)
+            var minLeaf = GetMinLeaf();
+            if (!minLeaf.HasValue)
             {
                 return 0;
             }
-            page = minValue.Value.Page;
+            page = minLeaf.Value.Page;
             entryIndex = 0;
         }
-        else
+        else if (!Search(
+                     startKey,
+                     startKeyExclusive ? SearchOperator.UpperBound : SearchOperator.LowerBound,
+                     out page,
+                     out entryIndex))
         {
-            PageNumber? nextPageNumber = RootPageNumber;
-            while (!TrySearch(
-                       nextPageNumber.Value,
-                       startKey,
-                       startKeyExclusive ? SearchOperator.UpperBound : SearchOperator.LowerBound,
-                       out page,
-                       out entryIndex,
-                       out nextPageNumber))
-            {
-                if (!nextPageNumber.HasValue) return 0;
-
-                PageCache.Load(nextPageNumber.Value);
-            }
+            return 0;
         }
 
         var count = 0;
@@ -544,7 +720,7 @@ class TreeWalker
                         entryIndex,
                         out var pageOffset,
                         out var keyLength,
-                        out var valueLength);
+                        out _);
 
                     // check end key
                     if (!endKey.IsEmpty)
@@ -569,11 +745,7 @@ class TreeWalker
                     return count;
                 }
 
-                var pageNumber = header.RightSiblingPageNumber;
-                while (!PageCache.TryGet(pageNumber, out page))
-                {
-                    PageCache.Load(pageNumber);
-                }
+                page = PageCache.GetOrLoad(header.RightSiblingPageNumber);
                 entryIndex = 0;
             }
             finally
@@ -598,29 +770,25 @@ class TreeWalker
         // find start position
         if (startKey.IsEmpty)
         {
-            var minValue = GetMinValue();
-            if (!minValue.HasValue)
+            var minLeaf = GetMinLeaf();
+            if (!minLeaf.HasValue)
             {
                 return 0;
             }
-            page = minValue.Value.Page;
+            page = minLeaf.Value.Page;
             entryIndex = 0;
         }
         else
         {
-            PageNumber? nextPageNumber = RootPageNumber;
-            while (!TrySearch(
-                       nextPageNumber.Value,
-                       startKey.Span,
-                       startKeyExclusive ? SearchOperator.UpperBound : SearchOperator.LowerBound,
-                       out page,
-                       out entryIndex,
-                       out nextPageNumber))
+            (var startPage, entryIndex) = await SearchAsync(
+                startKey,
+                startKeyExclusive ? SearchOperator.UpperBound : SearchOperator.LowerBound,
+                cancellationToken).ConfigureAwait(false);
+            if (startPage == null)
             {
-                if (!nextPageNumber.HasValue) return 0;
-
-                await PageCache.LoadAsync(nextPageNumber.Value, cancellationToken).ConfigureAwait(false);
+                return 0;
             }
+            page = startPage;
         }
 
         var count = 0;
@@ -647,7 +815,7 @@ class TreeWalker
                         entryIndex,
                         out var pageOffset,
                         out var keyLength,
-                        out var valueLength);
+                        out _);
 
                     // check end key
                     if (!endKey.IsEmpty)
@@ -672,11 +840,8 @@ class TreeWalker
                     return count;
                 }
 
-                var pageNumber = header.RightSiblingPageNumber;
-                while (!PageCache.TryGet(pageNumber, out page))
-                {
-                    await PageCache.LoadAsync(pageNumber, cancellationToken).ConfigureAwait(false);
-                }
+                page = await PageCache.GetOrLoadAsync(header.RightSiblingPageNumber, cancellationToken)
+                    .ConfigureAwait(false);
                 entryIndex = 0;
             }
             finally
@@ -696,14 +861,8 @@ class TreeWalker
         // Read the blob page number from the leaf's inline payload (8 bytes)
         var blobPageNumberValue = Unsafe.ReadUnaligned<long>(
             ref Unsafe.Add(ref MemoryMarshal.GetReference(leafPage.Memory.Span), valueOffset));
-        var blobPageNumber = new PageNumber(blobPageNumberValue);
 
-        IPageEntry blobPage;
-        while (!PageCache.TryGet(blobPageNumber, out blobPage))
-        {
-            PageCache.Load(blobPageNumber);
-        }
-
+        var blobPage = PageCache.GetOrLoad(new PageNumber(blobPageNumberValue));
         var blobLength = blobPage.GetLength() - BlobDataOffset;
         return new PageSlice(blobPage, BlobDataOffset, blobLength);
     }
@@ -717,174 +876,10 @@ class TreeWalker
 
         var blobPageNumberValue = Unsafe.ReadUnaligned<long>(
             ref Unsafe.Add(ref MemoryMarshal.GetReference(leafPage.Memory.Span), valueOffset));
-        var blobPageNumber = new PageNumber(blobPageNumberValue);
 
-        IPageEntry blobPage;
-        while (!PageCache.TryGet(blobPageNumber, out blobPage))
-        {
-            await PageCache.LoadAsync(blobPageNumber, ct).ConfigureAwait(false);
-        }
-
+        var blobPage = await PageCache.GetOrLoadAsync(new PageNumber(blobPageNumberValue), ct).ConfigureAwait(false);
         var blobLength = blobPage.GetLength() - BlobDataOffset;
         return new PageSlice(blobPage, BlobDataOffset, blobLength);
-    }
-
-    internal bool TryFindFrom(
-        PageNumber from,
-        scoped ReadOnlySpan<byte> key,
-        out int entryIndex,
-        out PageSlice value,
-        out PageNumber? next)
-    {
-        var pageNumber = from;
-        while (true)
-        {
-            if (!TryGetPage(pageNumber, out var page, out var pinned))
-            {
-                entryIndex = default;
-                value = default;
-                next = pageNumber;
-                return false;
-            }
-
-            var pageSpan = page.Memory.Span;
-            var header = NodeHeader.Parse(pageSpan);
-            if (header.Kind == NodeKind.Internal)
-            {
-                var internalNode = new InternalNodeReader(pageSpan, header.EntryCount);
-                if (!internalNode.TrySearch(key, comparer, out pageNumber))
-                {
-                    if (!pinned) page.Release();
-                    entryIndex = default;
-                    value = default;
-                    next = null;
-                    return false;
-                }
-
-                if (!pinned) page.Release();
-            }
-            else // Leaf
-            {
-                next = null;
-
-                var leafNode = new LeafNodeReader(pageSpan, header.EntryCount);
-                if (leafNode.TryFindValue(key, comparer, out entryIndex, out var valueOffset, out var valueLength))
-                {
-                    if (LeafNodeReader.IsOverflow(valueLength))
-                    {
-                        var resolved = ResolveValue(page, valueOffset, valueLength);
-                        if (!pinned) page.Release();
-                        value = resolved;
-                    }
-                    else
-                    {
-                        // The caller releases the page via PageSlice.Dispose; the pin must
-                        // stay balanced, so hand out an extra reference.
-                        if (pinned) page.Retain();
-                        value = new PageSlice(page, valueOffset, valueLength);
-                    }
-                    return true;
-                }
-
-                if (!pinned) page.Release();
-                value = default;
-                return false;
-            }
-        }
-    }
-
-    /// <summary>
-    /// Get a page from the cache. The root page is served from <see cref="pinnedRoot"/>
-    /// without touching the cache; <paramref name="pinned"/> indicates that the returned
-    /// entry holds no extra reference and must not be released by the caller.
-    /// </summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    bool TryGetPage(PageNumber pageNumber, out IPageEntry page, out bool pinned)
-    {
-        if (pageNumber == RootPageNumber)
-        {
-            var root = pinnedRoot;
-            if (root != null)
-            {
-                page = root;
-                pinned = true;
-                return true;
-            }
-
-            if (!PageCache.TryGet(pageNumber, out page))
-            {
-                pinned = false;
-                return false;
-            }
-
-            // Transfer the reference we just acquired to the pin. If another thread won
-            // the race, keep using our own reference (released by the caller as usual).
-            pinned = Interlocked.CompareExchange(ref pinnedRoot, page, null) == null;
-            return true;
-        }
-
-        pinned = false;
-        return PageCache.TryGet(pageNumber, out page);
-    }
-
-    internal bool TrySearch(
-        scoped ReadOnlySpan<byte> key,
-        SearchOperator op,
-        out IPageEntry page,
-        out int index,
-        out PageNumber? nextPageNumber) =>
-        TrySearch(RootPageNumber, key, op, out page, out index, out nextPageNumber);
-
-    internal bool TrySearch(
-        PageNumber from,
-        scoped ReadOnlySpan<byte> key,
-        SearchOperator op,
-        out IPageEntry page,
-        out int index,
-        out PageNumber? nextPageNumber)
-    {
-        var pageNumber = from;
-        while (true)
-        {
-            if (!TryGetPage(pageNumber, out page, out var pinned))
-            {
-                index = default;
-                nextPageNumber = pageNumber;
-                return false;
-            }
-
-            var pageSpan = page.Memory.Span;
-            var header = NodeHeader.Parse(pageSpan);
-            if (header.Kind == NodeKind.Internal)
-            {
-                var internalNode = new InternalNodeReader(pageSpan, header.EntryCount);
-                if (!internalNode.TrySearch(key, comparer, out pageNumber))
-                {
-                    if (!pinned) page.Release();
-                    index = default;
-                    nextPageNumber = null;
-                    return false;
-                }
-
-                if (!pinned) page.Release();
-            }
-            else // Leaf
-            {
-                nextPageNumber = null;
-
-                var leafNode = new LeafNodeReader(pageSpan, header.EntryCount);
-                if (leafNode.TrySearch(key, op, comparer, out index))
-                {
-                    // The caller owns (and releases) the returned leaf page.
-                    if (pinned) page.Retain();
-                    return true;
-                }
-
-                if (!pinned) page.Release();
-                index = default;
-                return false;
-            }
-        }
     }
 
     internal SingleValueResult GetMinValue()
@@ -938,34 +933,29 @@ class TreeWalker
         var pageNumber = RootPageNumber;
         while (true)
         {
-            IPageEntry page;
-            while (!PageCache.TryGet(pageNumber, out page))
-            {
-                PageCache.Load(pageNumber);
-            }
-
-            var pageSpan = page.Memory.Span;
+            var lease = GetPage(pageNumber);
+            var pageSpan = lease.Page.Memory.Span;
             var header = NodeHeader.Parse(pageSpan);
             if (header.Kind == NodeKind.Internal)
             {
                 if (header.EntryCount <= 0)
                 {
-                    page.Release();
+                    lease.Release();
                     return null;
                 }
 
                 var internalNode = new InternalNodeReader(pageSpan, header.EntryCount);
                 internalNode.GetAt(0, out _, out pageNumber);
-                page.Release();
+                lease.Release();
             }
             else // Leaf
             {
                 if (header.EntryCount <= 0)
                 {
-                    page.Release();
+                    lease.Release();
                     return null;
                 }
-                return (page, 0);
+                return (lease.Take(), 0);
             }
         }
     }
@@ -975,32 +965,29 @@ class TreeWalker
         var pageNumber = RootPageNumber;
         while (true)
         {
-            IPageEntry page;
-            while (!PageCache.TryGet(pageNumber, out page))
-            {
-                PageCache.Load(pageNumber);
-            }
-
-            var pageSpan = page.Memory.Span;
+            var lease = GetPage(pageNumber);
+            var pageSpan = lease.Page.Memory.Span;
             var header = NodeHeader.Parse(pageSpan);
             if (header.Kind == NodeKind.Internal)
             {
                 if (header.EntryCount <= 0)
                 {
+                    lease.Release();
                     return null;
                 }
 
                 var internalNode = new InternalNodeReader(pageSpan, header.EntryCount);
                 internalNode.GetAt(header.EntryCount - 1, out _, out pageNumber);
-                page.Release();
+                lease.Release();
             }
             else // Leaf
             {
                 if (header.EntryCount <= 0)
                 {
+                    lease.Release();
                     return null;
                 }
-                return (page, header.EntryCount - 1);
+                return (lease.Take(), header.EntryCount - 1);
             }
         }
     }
@@ -1014,79 +1001,32 @@ class TreeWalker
             return GetMaxValueLeaf();
         }
 
-        // Find the leaf page containing endKey using UpperBound or LowerBound
-        PageNumber? nextPageNumber = RootPageNumber;
-        IPageEntry page;
-        int entryIndex;
-
+        // Find the first entry beyond the end bound, then step one back.
         var op = endKeyExclusive ? SearchOperator.LowerBound : SearchOperator.UpperBound;
-        if (TrySearch(nextPageNumber.Value, endKey, op, out page, out entryIndex, out nextPageNumber))
+        if (!Search(endKey, op, out var page, out var entryIndex))
         {
-            // TrySearch found an entry at entryIndex. We want the entry just before it.
-            entryIndex--;
-            if (entryIndex < 0)
-            {
-                // Need to go to the left sibling page
-                var header = NodeHeader.Parse(page.Memory.Span);
-                if (header.LeftSiblingPageNumber.IsEmpty)
-                {
-                    page.Release();
-                    return null;
-                }
-
-                var leftPageNumber = header.LeftSiblingPageNumber;
-                page.Release();
-
-                while (!PageCache.TryGet(leftPageNumber, out page))
-                {
-                    PageCache.Load(leftPageNumber);
-                }
-                var leftHeader = NodeHeader.Parse(page.Memory.Span);
-                entryIndex = leftHeader.EntryCount - 1;
-            }
-            return (page, entryIndex);
-        }
-
-        if (!nextPageNumber.HasValue)
-        {
-            // TrySearch returned false and no next page - all entries satisfy the condition
-            // Re-search from root to find the leaf and use its last entry
-            // This means endKey is beyond all entries, so use max leaf
+            // Every entry satisfies the bound: start from the maximum.
             return GetMaxValueLeaf();
         }
 
-        // Need to load more pages
-        while (nextPageNumber.HasValue)
+        entryIndex--;
+        if (entryIndex < 0)
         {
-            PageCache.Load(nextPageNumber.Value);
-            if (TrySearch(nextPageNumber.Value, endKey, op, out page, out entryIndex, out nextPageNumber))
+            // Need to go to the left sibling page
+            var header = NodeHeader.Parse(page.Memory.Span);
+            if (header.LeftSiblingPageNumber.IsEmpty)
             {
-                entryIndex--;
-                if (entryIndex < 0)
-                {
-                    var header = NodeHeader.Parse(page.Memory.Span);
-                    if (header.LeftSiblingPageNumber.IsEmpty)
-                    {
-                        page.Release();
-                        return null;
-                    }
-
-                    var leftPageNumber = header.LeftSiblingPageNumber;
-                    page.Release();
-
-                    while (!PageCache.TryGet(leftPageNumber, out page))
-                    {
-                        PageCache.Load(leftPageNumber);
-                    }
-                    var leftHeader = NodeHeader.Parse(page.Memory.Span);
-                    entryIndex = leftHeader.EntryCount - 1;
-                }
-                return (page, entryIndex);
+                page.Release();
+                return null;
             }
-        }
 
-        // endKey is beyond all entries
-        return GetMaxValueLeaf();
+            var leftPageNumber = header.LeftSiblingPageNumber;
+            page.Release();
+
+            page = PageCache.GetOrLoad(leftPageNumber);
+            entryIndex = NodeHeader.Parse(page.Memory.Span).EntryCount - 1;
+        }
+        return (page, entryIndex);
     }
 
     async ValueTask<(IPageEntry Page, int EntryIndex)?> FindDescendingStartAsync(
@@ -1099,69 +1039,30 @@ class TreeWalker
             return GetMaxValueLeaf();
         }
 
-        PageNumber? nextPageNumber = RootPageNumber;
-
         var op = endKeyExclusive ? SearchOperator.LowerBound : SearchOperator.UpperBound;
-        if (TrySearch(nextPageNumber.Value, endKey.Span, op, out var page, out var entryIndex, out nextPageNumber))
-        {
-            entryIndex--;
-            if (entryIndex < 0)
-            {
-                var header = NodeHeader.Parse(page.Memory.Span);
-                if (header.LeftSiblingPageNumber.IsEmpty)
-                {
-                    page.Release();
-                    return null;
-                }
-
-                var leftPageNumber = header.LeftSiblingPageNumber;
-                page.Release();
-
-                while (!PageCache.TryGet(leftPageNumber, out page))
-                {
-                    await PageCache.LoadAsync(leftPageNumber, cancellationToken).ConfigureAwait(false);
-                }
-                var leftHeader = NodeHeader.Parse(page.Memory.Span);
-                entryIndex = leftHeader.EntryCount - 1;
-            }
-            return (page, entryIndex);
-        }
-
-        if (!nextPageNumber.HasValue)
+        var (page, entryIndex) = await SearchAsync(endKey, op, cancellationToken).ConfigureAwait(false);
+        if (page == null)
         {
             return GetMaxValueLeaf();
         }
 
-        while (nextPageNumber.HasValue)
+        entryIndex--;
+        if (entryIndex < 0)
         {
-            await PageCache.LoadAsync(nextPageNumber.Value, cancellationToken).ConfigureAwait(false);
-            if (TrySearch(nextPageNumber.Value, endKey.Span, op, out page, out entryIndex, out nextPageNumber))
+            var header = NodeHeader.Parse(page.Memory.Span);
+            if (header.LeftSiblingPageNumber.IsEmpty)
             {
-                entryIndex--;
-                if (entryIndex < 0)
-                {
-                    var header = NodeHeader.Parse(page.Memory.Span);
-                    if (header.LeftSiblingPageNumber.IsEmpty)
-                    {
-                        page.Release();
-                        return null;
-                    }
-
-                    var leftPageNumber = header.LeftSiblingPageNumber;
-                    page.Release();
-
-                    while (!PageCache.TryGet(leftPageNumber, out page))
-                    {
-                        await PageCache.LoadAsync(leftPageNumber, cancellationToken).ConfigureAwait(false);
-                    }
-                    var leftHeader = NodeHeader.Parse(page.Memory.Span);
-                    entryIndex = leftHeader.EntryCount - 1;
-                }
-                return (page, entryIndex);
+                page.Release();
+                return null;
             }
-        }
 
-        return GetMaxValueLeaf();
+            var leftPageNumber = header.LeftSiblingPageNumber;
+            page.Release();
+
+            page = await PageCache.GetOrLoadAsync(leftPageNumber, cancellationToken).ConfigureAwait(false);
+            entryIndex = NodeHeader.Parse(page.Memory.Span).EntryCount - 1;
+        }
+        return (page, entryIndex);
     }
 
     void ValidateRange(ReadOnlySpan<byte> startKey, ReadOnlySpan<byte> endKey)

--- a/src/DryDB/Internal/PageCache.cs
+++ b/src/DryDB/Internal/PageCache.cs
@@ -62,6 +62,11 @@ public sealed class PageCache : IDisposable
             get => memory;
         }
 
+        // Once the refcount reaches zero the entry is stamped with this bias so that
+        // late optimistic increments (see TryRetainIfAlive) can never make a dead entry
+        // look alive again. Far larger in magnitude than any possible reader count.
+        const int DeadBias = int.MinValue / 2;
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Retain()
         {
@@ -73,18 +78,23 @@ public sealed class PageCache : IDisposable
         public bool TryRetainIfAlive()
         {
             if (!refCounted) return true;
-            while (true)
+
+            // Optimistic fetch-add instead of a CAS loop: one atomic op that always
+            // succeeds, which scales far better under contention (no retry storms).
+            // The entry object itself is GC-managed, so touching the counter of a dead
+            // entry is safe — only the buffer must not be used.
+            //
+            //   result >= 1 : the entry was alive (or a racing releaser is about to
+            //                 attempt the dead-stamp CAS, which our increment defeats).
+            //   result <= 0 : the entry was already stamped dead; undo and fail.
+            var result = Interlocked.Increment(ref RefCount);
+            if (result >= 1)
             {
-                var current = Volatile.Read(ref RefCount);
-                if (current <= 0)
-                    return false;
-
-                var next = current + 1;
-
-                int original = Interlocked.CompareExchange(ref RefCount, next, current);
-                if (original == current)
-                    return true;
+                return true;
             }
+
+            Interlocked.Decrement(ref RefCount);
+            return false;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -93,7 +103,13 @@ public sealed class PageCache : IDisposable
             if (!refCounted) return;
             if (Interlocked.Decrement(ref RefCount) == 0)
             {
-                Buffer?.Dispose();
+                // Stamp the entry dead before disposing. If a concurrent optimistic
+                // retain slipped in after our decrement, the CAS fails and the entry
+                // stays alive — that reader now owns it and will release it later.
+                if (Interlocked.CompareExchange(ref RefCount, DeadBias, 0) == 0)
+                {
+                    Buffer?.Dispose();
+                }
             }
         }
     }

--- a/src/DryDB/Internal/PageCache.cs
+++ b/src/DryDB/Internal/PageCache.cs
@@ -2,7 +2,6 @@ using System;
 using System.Buffers;
 using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -34,19 +33,6 @@ public sealed class PageCache : IDisposable
             }
         }
 
-        /// <summary>
-        /// When false, the buffer is left to the GC once nothing references the entry, and
-        /// all reference counting is a no-op — reads become interlocked-free. Buffers over
-        /// unmanaged memory (e.g. Unity's NativeArray loader) must always be reference
-        /// counted so that they can be disposed deterministically.
-        /// </summary>
-        public required bool RefCounted
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => refCounted;
-            init => refCounted = value;
-        }
-
         public QueueTag Tag { get; set; }
 
         public int RefCount;
@@ -54,7 +40,6 @@ public sealed class PageCache : IDisposable
 
         IMemoryOwner<byte>? buffer;
         readonly ReadOnlyMemory<byte> memory;
-        readonly bool refCounted;
 
         public ReadOnlyMemory<byte> Memory
         {
@@ -70,15 +55,12 @@ public sealed class PageCache : IDisposable
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Retain()
         {
-            if (!refCounted) return;
             Interlocked.Increment(ref RefCount);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool TryRetainIfAlive()
         {
-            if (!refCounted) return true;
-
             // Optimistic fetch-add instead of a CAS loop: one atomic op that always
             // succeeds, which scales far better under contention (no retry storms).
             // The entry object itself is GC-managed, so touching the counter of a dead
@@ -100,7 +82,6 @@ public sealed class PageCache : IDisposable
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Release()
         {
-            if (!refCounted) return;
             if (Interlocked.Decrement(ref RefCount) == 0)
             {
                 // Stamp the entry dead before disposing. If a concurrent optimistic
@@ -124,7 +105,6 @@ public sealed class PageCache : IDisposable
     readonly IPageLoader pageLoader;
     readonly int capacity;
     readonly IPageFilter[]? filters;
-    readonly bool gcReclamation;
     readonly int sTargetSize;
     readonly int mTargetSize;
 
@@ -138,13 +118,11 @@ public sealed class PageCache : IDisposable
         int capacity,
         IPageFilter[]? filters,
         double smallFraction = 0.2,
-        double ghostFraction = 1.0,
-        bool gcReclamation = true)
+        double ghostFraction = 1.0)
     {
         this.pageLoader = pageLoader;
         this.capacity = capacity;
         this.filters = filters;
-        this.gcReclamation = gcReclamation;
 
         sTargetSize = Math.Max(2, (int)(capacity * smallFraction));
         mTargetSize = capacity - sTargetSize;
@@ -269,15 +247,10 @@ public sealed class PageCache : IDisposable
 
     bool TryPublish(PageNumber pageNumber, IMemoryOwner<byte> buffer, out IPageEntry page)
     {
-        // Unmanaged buffers must always be reference counted; array-backed buffers only
-        // when deterministic pooling is requested (PageReclamation.ReferenceCounted).
-        var refCounted = !gcReclamation || !MemoryMarshal.TryGetArray(buffer.Memory, out ArraySegment<byte> _);
-
         var entry = new Entry
         {
             PageNumber = pageNumber,
             Buffer = buffer,
-            RefCounted = refCounted,
             Frequency = 1,
             Tag = QueueTag.None,
             // One reference for the map, one handed to the caller.

--- a/src/DryDB/Internal/PageCache.cs
+++ b/src/DryDB/Internal/PageCache.cs
@@ -2,6 +2,7 @@ using System;
 using System.Buffers;
 using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -30,15 +31,28 @@ public sealed class PageCache : IDisposable
                 buffer = value;
                 // cache the Memory to avoid the virtual IMemoryOwner<byte>.Memory call per access
                 memory = value?.Memory ?? default;
+                // Array-backed buffers are reclaimed by the GC once nothing references
+                // the entry, so they need no reference counting at all — reads become
+                // interlocked-free. Buffers over unmanaged memory (e.g. Unity's
+                // NativeArray loader) must be disposed deterministically and keep the
+                // refcount protocol.
+                requiresDispose = value != null && !MemoryMarshal.TryGetArray(memory, out _);
             }
         }
         public QueueTag Tag { get; set; }
+
+        public bool RequiresDispose
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => requiresDispose;
+        }
 
         public int RefCount;
         public int Frequency;
 
         IMemoryOwner<byte>? buffer;
         readonly ReadOnlyMemory<byte> memory;
+        readonly bool requiresDispose;
 
         public ReadOnlyMemory<byte> Memory
         {
@@ -49,12 +63,14 @@ public sealed class PageCache : IDisposable
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Retain()
         {
+            if (!requiresDispose) return;
             Interlocked.Increment(ref RefCount);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool TryRetainIfAlive()
         {
+            if (!requiresDispose) return true;
             while (true)
             {
                 var current = Volatile.Read(ref RefCount);
@@ -72,6 +88,7 @@ public sealed class PageCache : IDisposable
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Release()
         {
+            if (!requiresDispose) return;
             if (Interlocked.Decrement(ref RefCount) == 0)
             {
                 Buffer?.Dispose();
@@ -111,9 +128,11 @@ public sealed class PageCache : IDisposable
         sTargetSize = Math.Max(2, (int)(capacity * smallFraction));
         mTargetSize = capacity - sTargetSize;
 
+        // The dictionary grows on demand; preallocating buckets for the full capacity
+        // (up to ~512k pages with the default CacheSize) wastes megabytes at open.
         map = new ConcurrentDictionary<PageNumber, Entry>(
             Environment.ProcessorCount,
-            capacity);
+            Math.Min(capacity, 4096));
 
         ghost = new ConcurrentDictionary<PageNumber, byte>(
             Environment.ProcessorCount,
@@ -151,8 +170,12 @@ public sealed class PageCache : IDisposable
             }
 
             // freq++（max: 3）
-            // Frequency is an approximate heuristic for S3-FIFO; a lost increment under
-            // contention is acceptable, so a single CAS attempt is enough (no retry loop).
+            // Frequency is an approximate heuristic for S3-FIFO, so a single CAS attempt
+            // is enough (no retry loop). The CAS must not be relaxed to a plain write:
+            // a stale overwrite would cancel the evictor's second-chance decrement and
+            // hot entries could never expire, livelocking the evict loop. With the CAS
+            // the reader's bump simply loses when it races the evictor. Once saturated
+            // at 3, readers stop writing the line entirely.
             var frequency = entry.Frequency;
             if (frequency < 3)
             {
@@ -165,20 +188,65 @@ public sealed class PageCache : IDisposable
         return false;
     }
 
+    /// <summary>
+    /// Get the page from the cache, loading it if necessary. The returned entry always
+    /// carries a reference owned by the caller (release it when done), so it stays valid
+    /// even if the page is evicted immediately after — which makes reads safe under
+    /// cache thrash. (The old load-then-relookup protocol could livelock: concurrent
+    /// loaders kept evicting each other's pages before they could be looked up again.)
+    /// </summary>
+    public IPageEntry GetOrLoad(PageNumber pageNumber)
+    {
+        while (true)
+        {
+            if (TryGet(pageNumber, out var page))
+            {
+                return page;
+            }
+
+            var buffer = pageLoader.ReadPage(pageNumber, filters);
+            if (TryPublish(pageNumber, buffer, out page))
+            {
+                return page;
+            }
+
+            // Lost the publish race: another thread's entry is in the map. Our buffer
+            // was never published, so it can be disposed directly.
+            buffer.Dispose();
+        }
+    }
+
+    /// <inheritdoc cref="GetOrLoad"/>
+    public async ValueTask<IPageEntry> GetOrLoadAsync(PageNumber pageNumber, CancellationToken cancellationToken = default)
+    {
+        while (true)
+        {
+            if (TryGet(pageNumber, out var page))
+            {
+                return page;
+            }
+
+            var buffer = await pageLoader.ReadPageAsync(pageNumber, filters, cancellationToken).ConfigureAwait(false);
+            if (TryPublish(pageNumber, buffer, out page))
+            {
+                return page;
+            }
+
+            buffer.Dispose();
+        }
+    }
+
     public void Load(PageNumber pageNumber)
     {
-        var buffer = pageLoader.ReadPage(pageNumber, filters);
-        AddEntry(pageNumber, buffer);
+        GetOrLoad(pageNumber).Release();
     }
 
     public async ValueTask LoadAsync(PageNumber pageNumber, CancellationToken cancellationToken = default)
     {
-        var buffer = await pageLoader.ReadPageAsync(pageNumber, filters, cancellationToken);
-        AddEntry(pageNumber, buffer);
+        (await GetOrLoadAsync(pageNumber, cancellationToken).ConfigureAwait(false)).Release();
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    void AddEntry(PageNumber pageNumber, IMemoryOwner<byte> buffer)
+    bool TryPublish(PageNumber pageNumber, IMemoryOwner<byte> buffer, out IPageEntry page)
     {
         var entry = new Entry
         {
@@ -186,13 +254,14 @@ public sealed class PageCache : IDisposable
             Buffer = buffer,
             Frequency = 1,
             Tag = QueueTag.None,
-            RefCount = 1
+            // One reference for the map, one handed to the caller.
+            RefCount = 2
         };
 
         if (!map.TryAdd(pageNumber, entry))
         {
-            // race
-            return;
+            page = null!;
+            return false;
         }
 
         var inGhost = ghost.ContainsKey(pageNumber);
@@ -221,6 +290,9 @@ public sealed class PageCache : IDisposable
         {
             TryStartEvict();
         }
+
+        page = entry;
+        return true;
     }
 
     void TryStartEvict()
@@ -231,9 +303,16 @@ public sealed class PageCache : IDisposable
 
         try
         {
-            while (map.Count > capacity)
+            // Bounded pass: second-chance re-insertions count as progress, so under
+            // heavy concurrent access a single pass could otherwise spin while readers
+            // keep refreshing frequencies. Leaving the map temporarily over capacity is
+            // fine — the next Load retries the eviction.
+            var attempts = capacity * 4;
+            while (map.Count > capacity && attempts-- > 0)
             {
-                EvictOne();
+                // Stop when neither queue can make progress (e.g. entries raced out of
+                // the queues); otherwise this would spin forever.
+                if (!EvictOne()) break;
             }
         }
         finally
@@ -242,23 +321,14 @@ public sealed class PageCache : IDisposable
         }
     }
 
-    void EvictOne()
+    bool EvictOne()
     {
         // If the approximate size of S is greater than the target, prioritize S; otherwise, prioritize M.
         if (Volatile.Read(ref approxSSize) >= sTargetSize)
         {
-            if (!EvictFromS())
-            {
-                EvictFromM();
-            }
+            return EvictFromS() || EvictFromM();
         }
-        else
-        {
-            if (!EvictFromM())
-            {
-                EvictFromS();
-            }
-        }
+        return EvictFromM() || EvictFromS();
     }
 
     bool EvictFromS()

--- a/src/DryDB/Internal/PageCache.cs
+++ b/src/DryDB/Internal/PageCache.cs
@@ -31,28 +31,30 @@ public sealed class PageCache : IDisposable
                 buffer = value;
                 // cache the Memory to avoid the virtual IMemoryOwner<byte>.Memory call per access
                 memory = value?.Memory ?? default;
-                // Array-backed buffers are reclaimed by the GC once nothing references
-                // the entry, so they need no reference counting at all — reads become
-                // interlocked-free. Buffers over unmanaged memory (e.g. Unity's
-                // NativeArray loader) must be disposed deterministically and keep the
-                // refcount protocol.
-                requiresDispose = value != null && !MemoryMarshal.TryGetArray(memory, out _);
             }
         }
-        public QueueTag Tag { get; set; }
 
-        public bool RequiresDispose
+        /// <summary>
+        /// When false, the buffer is left to the GC once nothing references the entry, and
+        /// all reference counting is a no-op — reads become interlocked-free. Buffers over
+        /// unmanaged memory (e.g. Unity's NativeArray loader) must always be reference
+        /// counted so that they can be disposed deterministically.
+        /// </summary>
+        public required bool RefCounted
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => requiresDispose;
+            get => refCounted;
+            init => refCounted = value;
         }
+
+        public QueueTag Tag { get; set; }
 
         public int RefCount;
         public int Frequency;
 
         IMemoryOwner<byte>? buffer;
         readonly ReadOnlyMemory<byte> memory;
-        readonly bool requiresDispose;
+        readonly bool refCounted;
 
         public ReadOnlyMemory<byte> Memory
         {
@@ -63,14 +65,14 @@ public sealed class PageCache : IDisposable
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Retain()
         {
-            if (!requiresDispose) return;
+            if (!refCounted) return;
             Interlocked.Increment(ref RefCount);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool TryRetainIfAlive()
         {
-            if (!requiresDispose) return true;
+            if (!refCounted) return true;
             while (true)
             {
                 var current = Volatile.Read(ref RefCount);
@@ -88,7 +90,7 @@ public sealed class PageCache : IDisposable
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Release()
         {
-            if (!requiresDispose) return;
+            if (!refCounted) return;
             if (Interlocked.Decrement(ref RefCount) == 0)
             {
                 Buffer?.Dispose();
@@ -106,6 +108,7 @@ public sealed class PageCache : IDisposable
     readonly IPageLoader pageLoader;
     readonly int capacity;
     readonly IPageFilter[]? filters;
+    readonly bool gcReclamation;
     readonly int sTargetSize;
     readonly int mTargetSize;
 
@@ -119,11 +122,13 @@ public sealed class PageCache : IDisposable
         int capacity,
         IPageFilter[]? filters,
         double smallFraction = 0.2,
-        double ghostFraction = 1.0)
+        double ghostFraction = 1.0,
+        bool gcReclamation = true)
     {
         this.pageLoader = pageLoader;
         this.capacity = capacity;
         this.filters = filters;
+        this.gcReclamation = gcReclamation;
 
         sTargetSize = Math.Max(2, (int)(capacity * smallFraction));
         mTargetSize = capacity - sTargetSize;
@@ -248,10 +253,15 @@ public sealed class PageCache : IDisposable
 
     bool TryPublish(PageNumber pageNumber, IMemoryOwner<byte> buffer, out IPageEntry page)
     {
+        // Unmanaged buffers must always be reference counted; array-backed buffers only
+        // when deterministic pooling is requested (PageReclamation.ReferenceCounted).
+        var refCounted = !gcReclamation || !MemoryMarshal.TryGetArray(buffer.Memory, out ArraySegment<byte> _);
+
         var entry = new Entry
         {
             PageNumber = pageNumber,
             Buffer = buffer,
+            RefCounted = refCounted,
             Frequency = 1,
             Tag = QueueTag.None,
             // One reference for the map, one handed to the caller.

--- a/src/DryDB/NonUniqueSecondaryIndexQuery.cs
+++ b/src/DryDB/NonUniqueSecondaryIndexQuery.cs
@@ -23,6 +23,8 @@ public class NonUniqueSecondaryIndexQuery : IKeyValueStore
             new DuplicateKeyEncoding(descriptor.KeyEncoding));
     }
 
+    internal void ReleasePinnedPages() => duplicateKeyTree.ReleasePinnedRoot();
+
     public SingleValueResult Get(ReadOnlySpan<byte> key)
     {
         Span<byte> minKeyBuffer = stackalloc byte[DuplicateKey.SizeOf(key.Length)];
@@ -78,11 +80,7 @@ public class NonUniqueSecondaryIndexQuery : IKeyValueStore
         foreach (var x in valueRefs)
         {
             var pageRef = PageRef.Parse(x.Span);
-            IPageEntry page;
-            while (!duplicateKeyTree.PageCache.TryGet(pageRef.PageNumber, out page))
-            {
-                duplicateKeyTree.PageCache.Load(pageRef.PageNumber);
-            }
+            var page = duplicateKeyTree.PageCache.GetOrLoad(pageRef.PageNumber);
             result.Add(page, pageRef.Start, pageRef.Length);
             page.Release();
         }
@@ -136,11 +134,7 @@ public class NonUniqueSecondaryIndexQuery : IKeyValueStore
         foreach (var x in valueRefs)
         {
             var pageRef = PageRef.Parse(x.Span);
-            IPageEntry page;
-            while (!duplicateKeyTree.PageCache.TryGet(pageRef.PageNumber, out page))
-            {
-                await duplicateKeyTree.PageCache.LoadAsync(pageRef.PageNumber, cancellationToken);
-            }
+            var page = await duplicateKeyTree.PageCache.GetOrLoadAsync(pageRef.PageNumber, cancellationToken);
             result.Add(page, pageRef.Start, pageRef.Length);
             page.Release();
         }

--- a/src/DryDB/RangeIterator.cs
+++ b/src/DryDB/RangeIterator.cs
@@ -113,20 +113,9 @@ public class RangeIterator :
 
     public bool TrySeek(ReadOnlySpan<byte> key)
     {
-        PageNumber? nextPageNumber = treeWalker.RootPageNumber;
-        IPageEntry page;
-        int entryIndex;
-
-        while (!treeWalker.TrySearch(
-                   nextPageNumber.Value,
-                   key,
-                   SearchOperator.Equal,
-                   out page,
-                   out entryIndex,
-                   out nextPageNumber))
+        if (!treeWalker.Search(key, SearchOperator.Equal, out var page, out var entryIndex))
         {
-            if (!nextPageNumber.HasValue) return false;
-            treeWalker.PageCache.Load(nextPageNumber.Value);
+            return false;
         }
 
         currentOverflowPage?.Release();
@@ -139,7 +128,7 @@ public class RangeIterator :
         }
         else
         {
-            // TrySearch acquired another reference to the page we already hold
+            // Search acquired another reference to the page we already hold
             page.Release();
         }
         currentEntryIndex = entryIndex;
@@ -150,20 +139,11 @@ public class RangeIterator :
         ReadOnlyMemory<byte> key,
         CancellationToken cancellationToken = default)
     {
-        PageNumber? nextPageNumber = treeWalker.RootPageNumber;
-        IPageEntry page;
-        int entryIndex;
-
-        while (!treeWalker.TrySearch(
-                   nextPageNumber.Value,
-                   key.Span,
-                   SearchOperator.Equal,
-                   out page,
-                   out entryIndex,
-                   out nextPageNumber))
+        var (page, entryIndex) = await treeWalker.SearchAsync(key, SearchOperator.Equal, cancellationToken)
+            .ConfigureAwait(false);
+        if (page == null)
         {
-            if (!nextPageNumber.HasValue) return false;
-            await treeWalker.PageCache.LoadAsync(nextPageNumber.Value, cancellationToken);
+            return false;
         }
 
         currentOverflowPage?.Release();
@@ -176,7 +156,7 @@ public class RangeIterator :
         }
         else
         {
-            // TrySearch acquired another reference to the page we already hold
+            // Search acquired another reference to the page we already hold
             page.Release();
         }
         currentEntryIndex = entryIndex;
@@ -217,10 +197,7 @@ public class RangeIterator :
             }
 
             currentPage.Release();
-            while (!pageCache.TryGet(header.RightSiblingPageNumber, out currentPage))
-            {
-                treeWalker.PageCache.Load(header.RightSiblingPageNumber);
-            }
+            currentPage = pageCache.GetOrLoad(header.RightSiblingPageNumber);
 
             header = currentPage.GetNodeHeader();
             if (header.Kind != NodeKind.Leaf)
@@ -269,10 +246,7 @@ public class RangeIterator :
             }
 
             currentPage.Release();
-            while (!pageCache.TryGet(header.LeftSiblingPageNumber, out currentPage))
-            {
-                treeWalker.PageCache.Load(header.LeftSiblingPageNumber);
-            }
+            currentPage = pageCache.GetOrLoad(header.LeftSiblingPageNumber);
 
             var leftHeader = currentPage.GetNodeHeader();
             if (leftHeader.Kind != NodeKind.Leaf)
@@ -328,10 +302,7 @@ public class RangeIterator :
             }
 
             currentPage.Release();
-            while (!pageCache.TryGet(header.RightSiblingPageNumber, out currentPage))
-            {
-                await treeWalker.PageCache.LoadAsync(header.RightSiblingPageNumber);
-            }
+            currentPage = await pageCache.GetOrLoadAsync(header.RightSiblingPageNumber).ConfigureAwait(false);
 
             header = currentPage.GetNodeHeader();
             if (header.Kind != NodeKind.Leaf)
@@ -380,10 +351,7 @@ public class RangeIterator :
             }
 
             currentPage.Release();
-            while (!pageCache.TryGet(header.LeftSiblingPageNumber, out currentPage))
-            {
-                await treeWalker.PageCache.LoadAsync(header.LeftSiblingPageNumber);
-            }
+            currentPage = await pageCache.GetOrLoadAsync(header.LeftSiblingPageNumber).ConfigureAwait(false);
 
             var leftHeader = currentPage.GetNodeHeader();
             if (leftHeader.Kind != NodeKind.Leaf)

--- a/src/DryDB/ReadOnlyDatabase.cs
+++ b/src/DryDB/ReadOnlyDatabase.cs
@@ -72,6 +72,10 @@ public sealed class ReadOnlyDatabase : IDisposable
 
     public void Dispose()
     {
+        foreach (var table in tables.Values)
+        {
+            table.ReleasePinnedPages();
+        }
         pageCache.Dispose();
         pageLoader.Dispose();
     }

--- a/src/DryDB/ReadOnlyDatabase.cs
+++ b/src/DryDB/ReadOnlyDatabase.cs
@@ -11,28 +11,6 @@ namespace DryDB;
 
 public delegate IPageLoader StorageFactory(Stream stream, int pageSize);
 
-public enum PageReclamation
-{
-    /// <summary>
-    /// <see cref="Gc"/> on CoreCLR; <see cref="ReferenceCounted"/> on Mono/IL2CPP (Unity),
-    /// where the conservative non-compacting GC makes per-load garbage expensive.
-    /// </summary>
-    Auto,
-
-    /// <summary>
-    /// Page buffers are reference counted and returned to the buffer pool deterministically.
-    /// Steady-state loads allocate nothing, at the cost of interlocked refcount traffic on
-    /// every page access (a contention point for parallel reads of hot pages).
-    /// </summary>
-    ReferenceCounted,
-
-    /// <summary>
-    /// Evicted page buffers are left to the garbage collector; reads perform no interlocked
-    /// operations at all. Best multi-thread read throughput; each page load allocates.
-    /// </summary>
-    Gc,
-}
-
 public record DatabaseLoadOptions
 {
     public static DatabaseLoadOptions Default => new();
@@ -53,14 +31,6 @@ public record DatabaseLoadOptions
     };
 
     public int CacheSize { get; set; } = 2000 * 1024 * 1024;
-
-    /// <summary>
-    /// How managed page buffers are reclaimed after eviction. Buffers over unmanaged
-    /// memory (e.g. the Unity NativeArray loader) are always reference counted
-    /// regardless of this setting, because only a refcount can release them safely.
-    /// </summary>
-    public PageReclamation PageReclamation { get; set; } = PageReclamation.Auto;
-
     public StorageFactory StorageFactory { get; set; } = DefaultStorageFactory;
 }
 
@@ -81,13 +51,6 @@ public sealed class ReadOnlyDatabase : IDisposable
         return new ReadOnlyDatabase(catalog, storage, options);
     }
 
-    // Mono (Unity editor/player) and IL2CPP use a conservative, non-compacting GC where
-    // per-load garbage hurts both peak memory and collection pauses — prefer deterministic
-    // pooling there. CoreCLR handles short-lived buffers cheaply.
-    static readonly bool GcReclamationByDefault =
-        Type.GetType("Mono.Runtime") == null &&
-        System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported;
-
     public Catalog Catalog { get; }
     readonly IPageLoader pageLoader;
     readonly PageCache pageCache;
@@ -98,17 +61,7 @@ public sealed class ReadOnlyDatabase : IDisposable
         Catalog = catalog;
         this.pageLoader = pageLoader;
         var pageCacheCapacity = Math.Max(options.CacheSize / catalog.PageSize, 8);
-        var gcReclamation = options.PageReclamation switch
-        {
-            PageReclamation.ReferenceCounted => false,
-            PageReclamation.Gc => true,
-            _ => GcReclamationByDefault,
-        };
-        pageCache = new PageCache(
-            pageLoader,
-            pageCacheCapacity,
-            catalog.Filters?.ToArray() ?? [],
-            gcReclamation: gcReclamation);
+        pageCache = new PageCache(pageLoader, pageCacheCapacity, catalog.Filters?.ToArray() ?? []);
 
         tables = new Dictionary<string, ReadOnlyTable>(catalog.TableDescriptors.Count);
         foreach (var descriptor in catalog.TableDescriptors.Values)

--- a/src/DryDB/ReadOnlyDatabase.cs
+++ b/src/DryDB/ReadOnlyDatabase.cs
@@ -11,6 +11,28 @@ namespace DryDB;
 
 public delegate IPageLoader StorageFactory(Stream stream, int pageSize);
 
+public enum PageReclamation
+{
+    /// <summary>
+    /// <see cref="Gc"/> on CoreCLR; <see cref="ReferenceCounted"/> on Mono/IL2CPP (Unity),
+    /// where the conservative non-compacting GC makes per-load garbage expensive.
+    /// </summary>
+    Auto,
+
+    /// <summary>
+    /// Page buffers are reference counted and returned to the buffer pool deterministically.
+    /// Steady-state loads allocate nothing, at the cost of interlocked refcount traffic on
+    /// every page access (a contention point for parallel reads of hot pages).
+    /// </summary>
+    ReferenceCounted,
+
+    /// <summary>
+    /// Evicted page buffers are left to the garbage collector; reads perform no interlocked
+    /// operations at all. Best multi-thread read throughput; each page load allocates.
+    /// </summary>
+    Gc,
+}
+
 public record DatabaseLoadOptions
 {
     public static DatabaseLoadOptions Default => new();
@@ -31,6 +53,14 @@ public record DatabaseLoadOptions
     };
 
     public int CacheSize { get; set; } = 2000 * 1024 * 1024;
+
+    /// <summary>
+    /// How managed page buffers are reclaimed after eviction. Buffers over unmanaged
+    /// memory (e.g. the Unity NativeArray loader) are always reference counted
+    /// regardless of this setting, because only a refcount can release them safely.
+    /// </summary>
+    public PageReclamation PageReclamation { get; set; } = PageReclamation.Auto;
+
     public StorageFactory StorageFactory { get; set; } = DefaultStorageFactory;
 }
 
@@ -48,20 +78,37 @@ public sealed class ReadOnlyDatabase : IDisposable
         options ??= DatabaseLoadOptions.Default;
         var catalog = await DryDBCodec.ParseCatalogAsync(stream, cancellationToken);
         var storage = options.StorageFactory.Invoke(stream, catalog.PageSize);
-        return new ReadOnlyDatabase(catalog, storage, options.CacheSize);
+        return new ReadOnlyDatabase(catalog, storage, options);
     }
+
+    // Mono (Unity editor/player) and IL2CPP use a conservative, non-compacting GC where
+    // per-load garbage hurts both peak memory and collection pauses — prefer deterministic
+    // pooling there. CoreCLR handles short-lived buffers cheaply.
+    static readonly bool GcReclamationByDefault =
+        Type.GetType("Mono.Runtime") == null &&
+        System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported;
 
     public Catalog Catalog { get; }
     readonly IPageLoader pageLoader;
     readonly PageCache pageCache;
     readonly Dictionary<string, ReadOnlyTable> tables;
 
-    ReadOnlyDatabase(Catalog catalog, IPageLoader pageLoader, int cacheSize)
+    ReadOnlyDatabase(Catalog catalog, IPageLoader pageLoader, DatabaseLoadOptions options)
     {
         Catalog = catalog;
         this.pageLoader = pageLoader;
-        var pageCacheCapacity = Math.Max(cacheSize / catalog.PageSize, 8);
-        pageCache = new PageCache(pageLoader, pageCacheCapacity, catalog.Filters?.ToArray() ?? []);
+        var pageCacheCapacity = Math.Max(options.CacheSize / catalog.PageSize, 8);
+        var gcReclamation = options.PageReclamation switch
+        {
+            PageReclamation.ReferenceCounted => false,
+            PageReclamation.Gc => true,
+            _ => GcReclamationByDefault,
+        };
+        pageCache = new PageCache(
+            pageLoader,
+            pageCacheCapacity,
+            catalog.Filters?.ToArray() ?? [],
+            gcReclamation: gcReclamation);
 
         tables = new Dictionary<string, ReadOnlyTable>(catalog.TableDescriptors.Count);
         foreach (var descriptor in catalog.TableDescriptors.Values)

--- a/src/DryDB/ReadOnlyTable.cs
+++ b/src/DryDB/ReadOnlyTable.cs
@@ -41,6 +41,23 @@ public sealed class ReadOnlyTable : IKeyValueStore
         }
     }
 
+    internal void ReleasePinnedPages()
+    {
+        primaryKeyTree.ReleasePinnedRoot();
+        foreach (var query in secondaryIndexQueries.Values)
+        {
+            switch (query)
+            {
+                case SecondaryIndexQuery q:
+                    q.ReleasePinnedPages();
+                    break;
+                case NonUniqueSecondaryIndexQuery q:
+                    q.ReleasePinnedPages();
+                    break;
+            }
+        }
+    }
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public SingleValueResult Get(ReadOnlySpan<byte> key) => primaryKeyTree.Get(key);
 

--- a/src/DryDB/SecondaryIndexQuery.cs
+++ b/src/DryDB/SecondaryIndexQuery.cs
@@ -17,6 +17,8 @@ public class SecondaryIndexQuery : IKeyValueStore
         tree = new TreeWalker(descriptor.RootPageNumber, pageCache, descriptor.KeyEncoding);
     }
 
+    internal void ReleasePinnedPages() => tree.ReleasePinnedRoot();
+
     public SingleValueResult Get(ReadOnlySpan<byte> key)
     {
         using var result = tree.Get(key);
@@ -27,11 +29,7 @@ public class SecondaryIndexQuery : IKeyValueStore
 
         var pageRef = PageRef.Parse(result.Value.Span);
 
-        IPageEntry page;
-        while (!tree.PageCache.TryGet(pageRef.PageNumber, out page))
-        {
-            tree.PageCache.Load(pageRef.PageNumber);
-        }
+        var page = tree.PageCache.GetOrLoad(pageRef.PageNumber);
 
         var pageSlice = new PageSlice(page, pageRef.Start, pageRef.Length);
         return new SingleValueResult(pageSlice, true);
@@ -49,11 +47,7 @@ public class SecondaryIndexQuery : IKeyValueStore
 
         var pageRef = PageRef.Parse(result.Value.Span);
 
-        IPageEntry page;
-        while (!tree.PageCache.TryGet(pageRef.PageNumber, out page))
-        {
-            await tree.PageCache.LoadAsync(pageRef.PageNumber, cancellationToken);
-        }
+        var page = await tree.PageCache.GetOrLoadAsync(pageRef.PageNumber, cancellationToken);
 
         var pageSlice = new PageSlice(page, pageRef.Start, pageRef.Length);
         return new SingleValueResult(pageSlice, true);
@@ -76,11 +70,7 @@ public class SecondaryIndexQuery : IKeyValueStore
         foreach (var x in pageRefs)
         {
             var pageRef = PageRef.Parse(x.Span);
-            IPageEntry page;
-            while (!tree.PageCache.TryGet(pageRef.PageNumber, out page))
-            {
-                tree.PageCache.Load(pageRef.PageNumber);
-            }
+            var page = tree.PageCache.GetOrLoad(pageRef.PageNumber);
             result.Add(page, pageRef.Start, pageRef.Length);
             page.Release();
         }
@@ -106,11 +96,7 @@ public class SecondaryIndexQuery : IKeyValueStore
         foreach (var x in pageRefs)
         {
             var pageRef = PageRef.Parse(x.Span);
-            IPageEntry page;
-            while (!tree.PageCache.TryGet(pageRef.PageNumber, out page))
-            {
-                await tree.PageCache.LoadAsync(pageRef.PageNumber, cancellationToken);
-            }
+            var page = await tree.PageCache.GetOrLoadAsync(pageRef.PageNumber, cancellationToken);
             result.Add(page, pageRef.Start, pageRef.Length);
             page.Release();
         }

--- a/tests/DryDB.Tests/ReadOnlyTableTest.cs
+++ b/tests/DryDB.Tests/ReadOnlyTableTest.cs
@@ -35,6 +35,61 @@ public class ReadOnlyTableTest
     }
 
     [Test]
+    public async Task Get_Concurrent_UnderEvictionPressure()
+    {
+        // 8-page cache against a table spanning dozens of pages, so that reads
+        // constantly race with eviction.
+        var table = await TestHelper.BuildTableAsync(
+            KeyEncoding.Ascii,
+            loadOptions: new DatabaseLoadOptions
+            {
+                CacheSize = 1024,
+            },
+            databaseConfigure: builder => builder.PageSize = 128,
+            tableConfigure: builder =>
+            {
+                for (var i = 0; i < 2000; i++)
+                {
+                    builder.Append(
+                        Encoding.ASCII.GetBytes($"key{i:D5}"),
+                        Encoding.ASCII.GetBytes($"value{i:D5}"));
+                }
+            });
+
+        var tasks = new List<Task>();
+        for (var t = 0; t < 4; t++)
+        {
+            var seed = t + 1;
+            tasks.Add(Task.Run(() =>
+            {
+                var random = new Random(seed);
+                for (var i = 0; i < 5000; i++)
+                {
+                    var k = random.Next(2000);
+                    using var result = table.Get(Encoding.ASCII.GetBytes($"key{k:D5}"));
+                    Assert.That(result.HasValue, Is.True);
+                    Assert.That(
+                        result.Value.Span.SequenceEqual(Encoding.ASCII.GetBytes($"value{k:D5}")),
+                        Is.True);
+                }
+            }));
+            tasks.Add(Task.Run(() =>
+            {
+                var random = new Random(seed * 100);
+                for (var i = 0; i < 200; i++)
+                {
+                    var start = random.Next(1900);
+                    using var result = table.GetRange(
+                        Encoding.ASCII.GetBytes($"key{start:D5}"),
+                        Encoding.ASCII.GetBytes($"key{start + 100:D5}"));
+                    Assert.That(result.Count, Is.EqualTo(101));
+                }
+            }));
+        }
+        await Task.WhenAll(tasks);
+    }
+
+    [Test]
     public async Task Get_TypedKey()
     {
         var table = await TestHelper.BuildTableAsync(

--- a/tests/DryDB.Tests/ReadOnlyTableTest.cs
+++ b/tests/DryDB.Tests/ReadOnlyTableTest.cs
@@ -34,8 +34,9 @@ public class ReadOnlyTableTest
         Assert.That(result2.HasValue, Is.False);
     }
 
-    [Test]
-    public async Task Get_Concurrent_UnderEvictionPressure()
+    [TestCase(PageReclamation.Gc)]
+    [TestCase(PageReclamation.ReferenceCounted)]
+    public async Task Get_Concurrent_UnderEvictionPressure(PageReclamation pageReclamation)
     {
         // 8-page cache against a table spanning dozens of pages, so that reads
         // constantly race with eviction.
@@ -44,6 +45,7 @@ public class ReadOnlyTableTest
             loadOptions: new DatabaseLoadOptions
             {
                 CacheSize = 1024,
+                PageReclamation = pageReclamation,
             },
             databaseConfigure: builder => builder.PageSize = 128,
             tableConfigure: builder =>

--- a/tests/DryDB.Tests/ReadOnlyTableTest.cs
+++ b/tests/DryDB.Tests/ReadOnlyTableTest.cs
@@ -34,9 +34,8 @@ public class ReadOnlyTableTest
         Assert.That(result2.HasValue, Is.False);
     }
 
-    [TestCase(PageReclamation.Gc)]
-    [TestCase(PageReclamation.ReferenceCounted)]
-    public async Task Get_Concurrent_UnderEvictionPressure(PageReclamation pageReclamation)
+    [Test]
+    public async Task Get_Concurrent_UnderEvictionPressure()
     {
         // 8-page cache against a table spanning dozens of pages, so that reads
         // constantly race with eviction.
@@ -45,7 +44,6 @@ public class ReadOnlyTableTest
             loadOptions: new DatabaseLoadOptions
             {
                 CacheSize = 1024,
-                PageReclamation = pageReclamation,
             },
             databaseConfigure: builder => builder.PageSize = 128,
             tableConfigure: builder =>

--- a/tests/DryDB.Tests/TreeWalkerTest.cs
+++ b/tests/DryDB.Tests/TreeWalkerTest.cs
@@ -25,31 +25,10 @@ public class TreeWalkerTest
                 { "key9"u8.ToArray(), "value9"u8.ToArray() },
             }, 128);
 
-        await tree.PageCache.LoadAsync(tree.RootPageNumber);
+        Assert.That(tree.Search("key0"u8, SearchOperator.Equal, out _, out _), Is.False);
 
-        var result = tree.TrySearch(
-            "key3"u8.ToArray(),
-            SearchOperator.Equal,
-            out _,
-            out var index,
-            out var nextPageNumber);
-
-        Assert.That(result, Is.False);
-        Assert.That(nextPageNumber.HasValue, Is.True);
-
-        var pageNumber = nextPageNumber.Value;
-        await tree.PageCache.LoadAsync(pageNumber);
-
-        result = tree.TrySearch(
-            "key3"u8.ToArray(),
-            SearchOperator.Equal,
-            out _,
-            out index,
-            out nextPageNumber);
+        var result = tree.Search("key3"u8, SearchOperator.Equal, out var page, out var index);
         Assert.That(result, Is.True);
-        Assert.That(nextPageNumber.HasValue, Is.False);
-
-        Assert.That(tree.PageCache.TryGet(pageNumber, out var page), Is.True);
 
         var nodeHeader = NodeHeader.Parse(page.Memory.Span);
         var leafNode = new LeafNodeReader(page.Memory.Span, nodeHeader.EntryCount);
@@ -59,6 +38,8 @@ public class TreeWalkerTest
         var value = page.Memory.Span.Slice(pageOffset + keyLength, valueLength);
         Assert.That(key.SequenceEqual("key3"u8), Is.True);
         Assert.That(value.SequenceEqual("value3"u8), Is.True);
+
+        page.Release();
     }
 
     [Test]
@@ -85,34 +66,8 @@ public class TreeWalkerTest
                 { "key16"u8.ToArray(), "value16"u8.ToArray() },
             }, 128);
 
-        await tree.PageCache.LoadAsync(tree.RootPageNumber);
-
-        var result = tree.TrySearch(
-            "key03"u8.ToArray(),
-            SearchOperator.LowerBound,
-            out _,
-            out var pos,
-            out var nextPageNumber);
-
-        Assert.That(result, Is.False);
-        Assert.That(nextPageNumber.HasValue, Is.True);
-
-        await tree.PageCache.LoadAsync(nextPageNumber!.Value);
-
-        var pageNumber = nextPageNumber.Value;
-
-        result = tree.TrySearch(
-            pageNumber,
-            "key03"u8.ToArray(),
-            SearchOperator.LowerBound,
-            out _,
-            out pos,
-            out nextPageNumber);
-
+        var result = tree.Search("key03"u8, SearchOperator.LowerBound, out var page, out var pos);
         Assert.That(result, Is.True);
-        Assert.That(nextPageNumber.HasValue, Is.False);
-
-        Assert.That(tree.PageCache.TryGet(pageNumber, out var page), Is.True);
 
         var header = NodeHeader.Parse(page.Memory.Span);
         var leafNode = new LeafNodeReader(page.Memory.Span, header.EntryCount);
@@ -122,6 +77,8 @@ public class TreeWalkerTest
         var value = page.Memory.Span.Slice(pageOffset + keyLength, valueLength);
         Assert.That(key.SequenceEqual("key03"u8), Is.True);
         Assert.That(value.SequenceEqual("value03"u8), Is.True);
+
+        page.Release();
     }
 
     [Test]
@@ -148,34 +105,8 @@ public class TreeWalkerTest
                 { "key16"u8.ToArray(), "value16"u8.ToArray() },
             }, 128);
 
-        await tree.PageCache.LoadAsync(tree.RootPageNumber);
-
-        var result = tree.TrySearch(
-            "key03"u8.ToArray(),
-            SearchOperator.UpperBound,
-            out _,
-            out var pos,
-            out var nextPageNumber);
-
-        Assert.That(result, Is.False);
-        Assert.That(nextPageNumber.HasValue, Is.True);
-
-        await tree.PageCache.LoadAsync(nextPageNumber!.Value);
-
-        var pageNumber = nextPageNumber.Value;
-
-        result = tree.TrySearch(
-            pageNumber,
-            "key03"u8.ToArray(),
-            SearchOperator.UpperBound,
-            out _,
-            out pos,
-            out nextPageNumber);
-
+        var result = tree.Search("key03"u8, SearchOperator.UpperBound, out var page, out var pos);
         Assert.That(result, Is.True);
-        Assert.That(nextPageNumber.HasValue, Is.False);
-
-        Assert.That(tree.PageCache.TryGet(pageNumber, out var page), Is.True);
 
         var header = NodeHeader.Parse(page.Memory.Span);
         var leafNode = new LeafNodeReader(page.Memory.Span, header.EntryCount);


### PR DESCRIPTION
## Summary

Read-path improvements that keep the original design (reference counting + deterministic buffer pooling, on every platform including Unity):

| Case | Before | After |
|---|---:|---:|
| Point lookup (single thread) | 20.2 µs | **19.1 µs** |
| Point lookup (8 threads, spread keys) | — | **185.6 µs** |
| Point lookup (8 threads, same key — worst case) | 1,440.9 µs | **827.2 µs (1.7x)** |
| CountRange (8,000 rows) | 1,524.6 µs | **160.3 µs (9.5x)** |
| GetRange (100 rows) | 140.0 µs | **100.9 µs (1.4x)** |

(1 op = 1000 queries for point lookups, 100 for range/count. All read paths remain zero-allocation.)

## `PageCache.GetOrLoad` — fixes a latent cache-thrash livelock

The old miss protocol (`while (!TryGet(pn)) Load(pn)`) is unsound under thrash: a loaded page can be evicted by concurrent loaders before the loading thread looks it up again, so concurrent loaders keep evicting each other's pages and nobody makes progress. A new stress test (8-page cache, concurrent point reads + range scans) spins forever on `main`.

`GetOrLoad` / `GetOrLoadAsync` now publish the entry with the caller's reference already taken (`RefCount = 2`), so the returned page stays valid even if it is evicted immediately after. All ~15 retry loops across `TreeWalker` / `RangeIterator` / secondary index queries are gone, which also simplifies the tree-walk code considerably. `TreeWalker.TrySearch`'s miss/resume protocol is replaced by self-sufficient `Search` / `SearchAsync`.

Two more hazards fixed along the way:
- The S3-FIFO frequency bump must stay a CAS (a plain write cancels the evictor's second-chance decrement, making hot entries unevictable — another livelock).
- The evict loop is now bounded per pass instead of spinning until under capacity.

## Optimistic fetch-add refcount

`TryRetainIfAlive` used a CAS retry loop, which degrades badly under contention (retry storms on the hot page's cache line). It is now a single `Interlocked.Increment` with a dead-entry bias: a result ≥ 1 means alive; once the count reaches zero, `Release` stamps the entry with `int.MinValue / 2` via a one-shot CAS before disposing, so late optimistic increments can never resurrect a dead entry. This is sound because the `Entry` object itself is GC-managed — only the buffer must not be touched after dispose.

Same-key parallel reads improve 1.7x; with realistically spread keys the refcount cost is within ~14% of having no refcount at all (a GC-based no-refcount mode was prototyped and measured, then dropped in favor of keeping one simple code path — see commit history).

## Per-leaf binary search for range bounds

`CountRange` compared every entry against the end key; since leaf entries are sorted, the bound is now located with one binary search per leaf and whole leaves are counted by subtraction (9.5x). `GetRange` (both directions, sync and async) uses the same bound computation, removing the per-row key comparison.

## Also

- `ReadOnlyDatabase.Dispose` now releases the pinned root pages (fixes a native-memory leak of one page per tree with the Unity NativeArray loader).
- `PageCache` no longer preallocates dictionary buckets for the full capacity (~MBs at open with the default 2 GB cache size).
- New benchmarks: spread-key parallel lookup; eviction-pressure concurrency stress test.

All 73 tests pass, including the new stress test that deadlocks on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)