### PR TITLE
Add key digest arrays to BTree nodes (format 1.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ DryDB is a read-only embedded B+Tree based key/value database, implemented pure 
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="docs/benchmarks/point_lookup_dark.svg">
-  <img alt="Point lookup benchmark: DryDB 25 ns, RocksDB 239 ns, SQLite (prepared + immutable) 709 ns, SQLite (default) 5,412 ns per query" src="docs/benchmarks/point_lookup_light.svg">
+  <img alt="Point lookup benchmark: DryDB 18 ns, RocksDB 383 ns, SQLite (prepared + immutable) 761 ns, SQLite (default) 5,648 ns per query" src="docs/benchmarks/point_lookup_light.svg">
 </picture>
 
 See [Performance](#performance) for details.
@@ -57,14 +57,14 @@ Two SQLite configurations are shown to keep the comparison fair:
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="docs/benchmarks/point_lookup_dark.svg">
-  <img alt="Point lookup benchmark: DryDB 25 ns, RocksDB 239 ns, SQLite (prepared + immutable) 709 ns, SQLite (default) 5,412 ns per query" src="docs/benchmarks/point_lookup_light.svg">
+  <img alt="Point lookup benchmark: DryDB 18 ns, RocksDB 383 ns, SQLite (prepared + immutable) 761 ns, SQLite (default) 5,648 ns per query" src="docs/benchmarks/point_lookup_light.svg">
 </picture>
 
 ### Range scan
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="docs/benchmarks/range_scan_dark.svg">
-  <img alt="Range scan benchmark (100 rows): DryDB 0.5 µs, SQLite (prepared + immutable) 6 µs, RocksDB 10.3 µs, SQLite (default) 10.5 µs per query" src="docs/benchmarks/range_scan_light.svg">
+  <img alt="Range scan benchmark (100 rows): DryDB 0.7 µs, SQLite (prepared + immutable) 8 µs, RocksDB 13.1 µs, SQLite (default) 15 µs per query" src="docs/benchmarks/range_scan_light.svg">
 </picture>
 
 ### Count by key range
@@ -77,27 +77,30 @@ Two SQLite configurations are shown to keep the comparison fair:
 <details>
 <summary>Raw BenchmarkDotNet results</summary>
 
-1 op = 1000 queries for point lookup, 100 queries for range scan and count. The `Parallel` variants run 8 threads of 1000 queries each: `ParallelSpread` reads spread-out keys (the realistic shape), `Parallel` hammers a single key (worst case for page refcount contention). `RandomKeys` defeats the branch predictor with a pseudo-random key sequence. `OpenAndFirstRead` opens the database file and runs one query.
+Each benchmark class is measured in its own run. 1 op = 1000 queries for point lookup, 100 queries for range scan and count. The `Parallel` variants run 8 threads of 1000 queries each: `ParallelSpread` reads spread-out keys (the realistic shape), `Parallel` hammers a single key (worst case for page refcount contention). `RandomKeys` defeats the branch predictor with a pseudo-random key sequence. `OpenAndFirstRead` opens the database file and runs one query. The `1M` variants read a 1,000,000-row (~45 MB) table where the working set no longer fits in the CPU cache.
 
-| Type           | Method                         | Mean         | Error        | StdDev     | Allocated  |
-|--------------- |------------------------------- |-------------:|-------------:|-----------:|-----------:|
-| ReadBenchmark  | DryDB_FindByKey                |     24.80 us |     2.017 us |   1.334 us |          - |
-| ReadBenchmark  | DryDB_FindByKeyAsync           |     27.81 us |     0.591 us |   0.391 us |          - |
-| ReadBenchmark  | DryDB_FindByKey_RandomKeys     |     43.37 us |     2.248 us |   1.176 us |          - |
-| ReadBenchmark  | DryDB_FindByKey_ParallelSpread |    213.66 us |     3.046 us |   1.812 us |     1550 B |
-| ReadBenchmark  | DryDB_FindByKey_Parallel       |    885.10 us |    20.434 us |  13.516 us |     1296 B |
-| ReadBenchmark  | RocksDB_FindByKey              |    239.35 us |     8.747 us |   5.205 us |    40032 B |
-| ReadBenchmark  | CsSqlite_FindByKey_Fair        |    708.89 us |     8.700 us |   4.550 us |    48000 B |
-| ReadBenchmark  | CsSqlite_FindByKey             |  5,412.34 us |   124.296 us |  73.967 us |    48000 B |
-| RangeBenchmark | DryDB_GetRange                 |     50.36 us |     3.490 us |   2.308 us |          - |
-| RangeBenchmark | CsSqlite_GetRange_Fair         |    597.25 us |    20.959 us |  13.863 us |   480000 B |
-| RangeBenchmark | RocksDB_GetRange               |  1,026.97 us |    47.101 us |  28.029 us |   726432 B |
-| RangeBenchmark | CsSqlite_GetRange              |  1,051.58 us |    35.486 us |  18.560 us |   480000 B |
-| CountBenchmark | DryDB_CountRange               |    112.00 us |     2.285 us |   1.511 us |          - |
-| CountBenchmark | CsSqlite_CountRange_Fair       |  9,253.18 us |   352.778 us | 233.341 us |          - |
-| CountBenchmark | CsSqlite_CountRange            |  9,566.06 us |   204.066 us | 106.731 us |          - |
-| CountBenchmark | RocksDB_CountRange             | 63,871.91 us | 1,284.642 us | 849.711 us | 25606432 B |
-| OpenBenchmark  | DryDB_OpenAndFirstRead         |    133.34 us |     6.287 us |   3.741 us |   639292 B |
+| Type             | Method                         | Mean         | Error        | StdDev       | Allocated  |
+|----------------- |------------------------------- |-------------:|-------------:|-------------:|-----------:|
+| ReadBenchmark    | DryDB_FindByKey                |     18.35 us |     0.155 us |     0.102 us |          - |
+| ReadBenchmark    | DryDB_FindByKeyAsync           |     23.23 us |     0.181 us |     0.119 us |          - |
+| ReadBenchmark    | DryDB_FindByKey_RandomKeys     |     33.75 us |     0.277 us |     0.165 us |          - |
+| ReadBenchmark    | DryDB_FindByKey_ParallelSpread |    231.72 us |    15.138 us |    10.013 us |     1549 B |
+| ReadBenchmark    | DryDB_FindByKey_Parallel       |    741.33 us |    13.685 us |     9.052 us |     1295 B |
+| ReadBenchmark    | RocksDB_FindByKey              |    382.77 us |    35.751 us |    23.647 us |    40032 B |
+| ReadBenchmark    | CsSqlite_FindByKey_Fair        |    761.17 us |    20.744 us |    10.850 us |    48000 B |
+| ReadBenchmark    | CsSqlite_FindByKey             |  5,648.13 us |   349.447 us |   231.138 us |    48000 B |
+| RangeBenchmark   | DryDB_GetRange                 |     65.51 us |     8.840 us |     5.847 us |          - |
+| RangeBenchmark   | CsSqlite_GetRange_Fair         |    801.38 us |    31.965 us |    16.719 us |   480000 B |
+| RangeBenchmark   | RocksDB_GetRange               |  1,308.55 us |   111.460 us |    73.724 us |   726432 B |
+| RangeBenchmark   | CsSqlite_GetRange              |  1,498.53 us |   105.935 us |    70.069 us |   480000 B |
+| CountBenchmark   | DryDB_CountRange               |    146.10 us |    11.450 us |     7.570 us |          - |
+| CountBenchmark   | CsSqlite_CountRange_Fair       | 11,384.10 us |   170.490 us |   101.450 us |          - |
+| CountBenchmark   | CsSqlite_CountRange            | 11,948.20 us |   382.170 us |   199.880 us |          - |
+| CountBenchmark   | RocksDB_CountRange             | 79,329.60 us | 3,939.950 us | 2,606.030 us | 25606432 B |
+| OpenBenchmark    | DryDB_OpenAndFirstRead         |    178.00 us |    31.360 us |    20.740 us |   652769 B |
+| BigReadBenchmark | DryDB_FindByKey_1M             |     53.91 us |     0.185 us |     0.122 us |          - |
+| BigReadBenchmark | DryDB_FindByKey_1M_RandomKeys  |     87.72 us |     1.339 us |     0.886 us |          - |
+| BigReadBenchmark | DryDB_GetRange_1M              |     47.78 us |     0.065 us |     0.039 us |          - |
 
 </details>
 

--- a/docs/benchmarks/count_range_dark.svg
+++ b/docs/benchmarks/count_range_dark.svg
@@ -5,18 +5,18 @@
     <text x="24" y="48" font-size="11.5" fill="#c3c2b7">Count 8,000 rows in a key range — time per query (lower is better)</text>
     <line x1="262" y1="58" x2="262" y2="203" stroke="#3a3936" stroke-width="1"/>
   <text x="250" y="75" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">DryDB</text>
-  <path d="M262 64 h2.09 a2.092391304347826 2.092391304347826 0 0 1 2.092391304347826 2.092391304347826 v17.815217391304348 a2.092391304347826 2.092391304347826 0 0 1 -2.092391304347826 2.092391304347826 h-2.09 Z" fill="#3987e5"/>
-  <text x="274.1847826086956" y="75" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">1.1 µs</text>
+  <path d="M262 64 h2.30 a2.3017902813299234 2.3017902813299234 0 0 1 2.3017902813299234 2.3017902813299234 v17.396419437340153 a2.3017902813299234 2.3017902813299234 0 0 1 -2.3017902813299234 2.3017902813299234 h-2.3 Z" fill="#3987e5"/>
+  <text x="274.60358056265983" y="75" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">1.5 µs</text>
   <text x="250" y="112" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">SQLite (CsSqlite, prepared + immutable)</text>
-  <path d="M262 101 h349.80 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-349.8 Z" fill="#8d8c82"/>
-  <text x="623.804347826087" y="112" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">93 µs</text>
+  <path d="M262 101 h345.87 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-345.87 Z" fill="#8d8c82"/>
+  <text x="619.8721227621484" y="112" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">114 µs</text>
   <text x="250" y="149" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">SQLite (CsSqlite, default)</text>
   <path d="M262 138 h361.22 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-361.22 Z" fill="#8d8c82"/>
-  <text x="635.2173913043479" y="149" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">96 µs</text>
+  <text x="635.2173913043479" y="149" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">119 µs</text>
   <text x="250" y="186" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">RocksDB</text>
   <path d="M262 175 h416.00 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-416 Z" fill="#8d8c82"/>
   <path d="M606.4 173 l-6 26 h7 l6 -26 Z" fill="#1a1a19"/>
-  <text x="690" y="186" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">639 µs</text>
+  <text x="690" y="186" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">793 µs</text>
     <text x="24" y="230" font-size="10.5" fill="#8a897f">BenchmarkDotNet · .NET 10 · Apple M-series · 10,000 rows (int64 key, 13-byte value) · 4 KB pages</text>
   </g>
 </svg>

--- a/docs/benchmarks/count_range_light.svg
+++ b/docs/benchmarks/count_range_light.svg
@@ -5,18 +5,18 @@
     <text x="24" y="48" font-size="11.5" fill="#52514e">Count 8,000 rows in a key range — time per query (lower is better)</text>
     <line x1="262" y1="58" x2="262" y2="203" stroke="#d8d7d2" stroke-width="1"/>
   <text x="250" y="75" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">DryDB</text>
-  <path d="M262 64 h2.09 a2.092391304347826 2.092391304347826 0 0 1 2.092391304347826 2.092391304347826 v17.815217391304348 a2.092391304347826 2.092391304347826 0 0 1 -2.092391304347826 2.092391304347826 h-2.09 Z" fill="#2a78d6"/>
-  <text x="274.1847826086956" y="75" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">1.1 µs</text>
+  <path d="M262 64 h2.30 a2.3017902813299234 2.3017902813299234 0 0 1 2.3017902813299234 2.3017902813299234 v17.396419437340153 a2.3017902813299234 2.3017902813299234 0 0 1 -2.3017902813299234 2.3017902813299234 h-2.3 Z" fill="#2a78d6"/>
+  <text x="274.60358056265983" y="75" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">1.5 µs</text>
   <text x="250" y="112" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">SQLite (CsSqlite, prepared + immutable)</text>
-  <path d="M262 101 h349.80 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-349.8 Z" fill="#7c7b74"/>
-  <text x="623.804347826087" y="112" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">93 µs</text>
+  <path d="M262 101 h345.87 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-345.87 Z" fill="#7c7b74"/>
+  <text x="619.8721227621484" y="112" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">114 µs</text>
   <text x="250" y="149" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">SQLite (CsSqlite, default)</text>
   <path d="M262 138 h361.22 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-361.22 Z" fill="#7c7b74"/>
-  <text x="635.2173913043479" y="149" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">96 µs</text>
+  <text x="635.2173913043479" y="149" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">119 µs</text>
   <text x="250" y="186" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">RocksDB</text>
   <path d="M262 175 h416.00 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-416 Z" fill="#7c7b74"/>
   <path d="M606.4 173 l-6 26 h7 l6 -26 Z" fill="#fcfcfb"/>
-  <text x="690" y="186" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">639 µs</text>
+  <text x="690" y="186" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">793 µs</text>
     <text x="24" y="230" font-size="10.5" fill="#8a897f">BenchmarkDotNet · .NET 10 · Apple M-series · 10,000 rows (int64 key, 13-byte value) · 4 KB pages</text>
   </g>
 </svg>

--- a/docs/benchmarks/point_lookup_dark.svg
+++ b/docs/benchmarks/point_lookup_dark.svg
@@ -5,18 +5,18 @@
     <text x="24" y="48" font-size="11.5" fill="#c3c2b7">Find one value by key, 10,000 rows — time per query (lower is better)</text>
     <line x1="262" y1="58" x2="262" y2="203" stroke="#3a3936" stroke-width="1"/>
   <text x="250" y="75" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">DryDB</text>
-  <path d="M262 64 h8.88 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-8.88 Z" fill="#3987e5"/>
-  <text x="282.87790519408844" y="75" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">25 ns</text>
+  <path d="M262 64 h4.64 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-4.64 Z" fill="#3987e5"/>
+  <text x="278.63851911100954" y="75" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">18 ns</text>
   <text x="250" y="112" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">RocksDB</text>
-  <path d="M262 101 h119.11 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-119.11 Z" fill="#8d8c82"/>
-  <text x="393.1127736554854" y="112" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">239 ns</text>
+  <path d="M262 101 h179.81 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-179.81 Z" fill="#8d8c82"/>
+  <text x="453.80848997314746" y="112" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">383 ns</text>
   <text x="250" y="149" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">SQLite (CsSqlite, prepared + immutable)</text>
   <path d="M262 138 h361.22 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-361.22 Z" fill="#8d8c82"/>
-  <text x="635.2173913043479" y="149" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">709 ns</text>
+  <text x="635.2173913043478" y="149" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">761 ns</text>
   <text x="250" y="186" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">SQLite (CsSqlite, default)</text>
   <path d="M262 175 h416.00 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-416 Z" fill="#8d8c82"/>
   <path d="M606.4 173 l-6 26 h7 l6 -26 Z" fill="#1a1a19"/>
-  <text x="690" y="186" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">5,412 ns</text>
+  <text x="690" y="186" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">5,648 ns</text>
     <text x="24" y="230" font-size="10.5" fill="#8a897f">BenchmarkDotNet · .NET 10 · Apple M-series · 10,000 rows (int64 key, 13-byte value) · 4 KB pages</text>
   </g>
 </svg>

--- a/docs/benchmarks/point_lookup_light.svg
+++ b/docs/benchmarks/point_lookup_light.svg
@@ -5,18 +5,18 @@
     <text x="24" y="48" font-size="11.5" fill="#52514e">Find one value by key, 10,000 rows — time per query (lower is better)</text>
     <line x1="262" y1="58" x2="262" y2="203" stroke="#d8d7d2" stroke-width="1"/>
   <text x="250" y="75" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">DryDB</text>
-  <path d="M262 64 h8.88 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-8.88 Z" fill="#2a78d6"/>
-  <text x="282.87790519408844" y="75" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">25 ns</text>
+  <path d="M262 64 h4.64 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-4.64 Z" fill="#2a78d6"/>
+  <text x="278.63851911100954" y="75" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">18 ns</text>
   <text x="250" y="112" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">RocksDB</text>
-  <path d="M262 101 h119.11 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-119.11 Z" fill="#7c7b74"/>
-  <text x="393.1127736554854" y="112" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">239 ns</text>
+  <path d="M262 101 h179.81 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-179.81 Z" fill="#7c7b74"/>
+  <text x="453.80848997314746" y="112" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">383 ns</text>
   <text x="250" y="149" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">SQLite (CsSqlite, prepared + immutable)</text>
   <path d="M262 138 h361.22 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-361.22 Z" fill="#7c7b74"/>
-  <text x="635.2173913043479" y="149" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">709 ns</text>
+  <text x="635.2173913043478" y="149" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">761 ns</text>
   <text x="250" y="186" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">SQLite (CsSqlite, default)</text>
   <path d="M262 175 h416.00 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-416 Z" fill="#7c7b74"/>
   <path d="M606.4 173 l-6 26 h7 l6 -26 Z" fill="#fcfcfb"/>
-  <text x="690" y="186" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">5,412 ns</text>
+  <text x="690" y="186" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">5,648 ns</text>
     <text x="24" y="230" font-size="10.5" fill="#8a897f">BenchmarkDotNet · .NET 10 · Apple M-series · 10,000 rows (int64 key, 13-byte value) · 4 KB pages</text>
   </g>
 </svg>

--- a/docs/benchmarks/range_scan_dark.svg
+++ b/docs/benchmarks/range_scan_dark.svg
@@ -5,17 +5,17 @@
     <text x="24" y="48" font-size="11.5" fill="#c3c2b7">Read 100 consecutive rows by key range — time per query (lower is better)</text>
     <line x1="262" y1="58" x2="262" y2="203" stroke="#3a3936" stroke-width="1"/>
   <text x="250" y="75" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">DryDB</text>
-  <path d="M262 64 h13.39 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-13.39 Z" fill="#3987e5"/>
-  <text x="287.39130434782606" y="75" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">0.5 µs</text>
+  <path d="M262 64 h13.04 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-13.04 Z" fill="#3987e5"/>
+  <text x="287.04347826086956" y="75" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">0.7 µs</text>
   <text x="250" y="112" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">SQLite (CsSqlite, prepared + immutable)</text>
-  <path d="M262 101 h204.70 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-204.7 Z" fill="#8d8c82"/>
-  <text x="478.69565217391306" y="112" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">6 µs</text>
+  <path d="M262 101 h190.78 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-190.78 Z" fill="#8d8c82"/>
+  <text x="464.7826086956522" y="112" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">8 µs</text>
   <text x="250" y="149" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">RocksDB</text>
-  <path d="M262 138 h354.26 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-354.26 Z" fill="#8d8c82"/>
-  <text x="628.2608695652175" y="149" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">10.3 µs</text>
+  <path d="M262 138 h314.96 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-314.96 Z" fill="#8d8c82"/>
+  <text x="588.9565217391305" y="149" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">13.1 µs</text>
   <text x="250" y="186" text-anchor="end" dominant-baseline="central" font-size="12" fill="#c3c2b7">SQLite (CsSqlite, default)</text>
   <path d="M262 175 h361.22 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-361.22 Z" fill="#8d8c82"/>
-  <text x="635.2173913043479" y="186" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">10.5 µs</text>
+  <text x="635.2173913043478" y="186" dominant-baseline="central" font-size="12" font-weight="600" fill="#ffffff">15 µs</text>
     <text x="24" y="230" font-size="10.5" fill="#8a897f">BenchmarkDotNet · .NET 10 · Apple M-series · 10,000 rows (int64 key, 13-byte value) · 4 KB pages</text>
   </g>
 </svg>

--- a/docs/benchmarks/range_scan_light.svg
+++ b/docs/benchmarks/range_scan_light.svg
@@ -5,17 +5,17 @@
     <text x="24" y="48" font-size="11.5" fill="#52514e">Read 100 consecutive rows by key range — time per query (lower is better)</text>
     <line x1="262" y1="58" x2="262" y2="203" stroke="#d8d7d2" stroke-width="1"/>
   <text x="250" y="75" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">DryDB</text>
-  <path d="M262 64 h13.39 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-13.39 Z" fill="#2a78d6"/>
-  <text x="287.39130434782606" y="75" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">0.5 µs</text>
+  <path d="M262 64 h13.04 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-13.04 Z" fill="#2a78d6"/>
+  <text x="287.04347826086956" y="75" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">0.7 µs</text>
   <text x="250" y="112" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">SQLite (CsSqlite, prepared + immutable)</text>
-  <path d="M262 101 h204.70 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-204.7 Z" fill="#7c7b74"/>
-  <text x="478.69565217391306" y="112" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">6 µs</text>
+  <path d="M262 101 h190.78 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-190.78 Z" fill="#7c7b74"/>
+  <text x="464.7826086956522" y="112" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">8 µs</text>
   <text x="250" y="149" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">RocksDB</text>
-  <path d="M262 138 h354.26 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-354.26 Z" fill="#7c7b74"/>
-  <text x="628.2608695652175" y="149" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">10.3 µs</text>
+  <path d="M262 138 h314.96 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-314.96 Z" fill="#7c7b74"/>
+  <text x="588.9565217391305" y="149" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">13.1 µs</text>
   <text x="250" y="186" text-anchor="end" dominant-baseline="central" font-size="12" fill="#52514e">SQLite (CsSqlite, default)</text>
   <path d="M262 175 h361.22 a4 4 0 0 1 4 4 v14 a4 4 0 0 1 -4 4 h-361.22 Z" fill="#7c7b74"/>
-  <text x="635.2173913043479" y="186" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">10.5 µs</text>
+  <text x="635.2173913043478" y="186" dominant-baseline="central" font-size="12" font-weight="600" fill="#0b0b0b">15 µs</text>
     <text x="24" y="230" font-size="10.5" fill="#8a897f">BenchmarkDotNet · .NET 10 · Apple M-series · 10,000 rows (int64 key, 13-byte value) · 4 KB pages</text>
   </g>
 </svg>

--- a/sandbox/DryDB.Benchmark/BigReadBenchmark.cs
+++ b/sandbox/DryDB.Benchmark/BigReadBenchmark.cs
@@ -1,0 +1,103 @@
+using System.Text;
+using BenchmarkDotNet.Attributes;
+
+namespace DryDB.Benchmark;
+
+/// <summary>
+/// Reads against a 1M-row table (~35 MB): unlike the 10k benchmarks, the tree is
+/// three levels deep and the working set does not fit in L2, so per-probe cache
+/// behaviour dominates.
+/// </summary>
+[Config(typeof(BenchmarkConfig))]
+public class BigReadBenchmark
+{
+    const int N = 1_000_000;
+    const int Iterations = 1000;
+    const long FindKey = 123_456;
+
+    DirectoryInfo directory = default!;
+    ReadOnlyDatabase database = default!;
+
+    [GlobalSetup]
+    public async Task SetupAsync()
+    {
+        directory = Directory.CreateTempSubdirectory("drydb_benchmarks_big");
+        var drydbPath = Path.Combine(directory.FullName, "big.drydb");
+
+        using (var builder = new DatabaseBuilder
+               {
+                   PageSize = 4096,
+               })
+        {
+            var tableBuilder = builder.CreateTable("items", KeyEncoding.Int64LittleEndian);
+            for (var i = 0; i < N; i++)
+            {
+                tableBuilder.Append(i, Encoding.UTF8.GetBytes($"val{i:D10}"));
+            }
+            await builder.BuildToFileAsync(drydbPath);
+        }
+
+        database = await ReadOnlyDatabase.OpenFileAsync(drydbPath);
+
+        // Touch every key once so that reads measure the cached hot path.
+        var table = database.GetTable("items");
+        for (var i = 0L; i < N; i += 50)
+        {
+            using var _ = table.Get(i);
+        }
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        database.Dispose();
+        try
+        {
+            directory.Delete(true);
+        }
+        catch (DirectoryNotFoundException) { }
+    }
+
+    [Benchmark(Baseline = true)]
+    public void DryDB_FindByKey_1M()
+    {
+        for (var i = 0; i < Iterations; i++)
+        {
+            var table = database.GetTable("items");
+            using var _ = table.Get(FindKey);
+        }
+    }
+
+    [Benchmark]
+    public void DryDB_FindByKey_1M_RandomKeys()
+    {
+        var seed = 123456789u;
+        for (var i = 0; i < Iterations; i++)
+        {
+            seed = seed * 1664525u + 1013904223u;
+            var table = database.GetTable("items");
+            using var _ = table.Get((long)(seed % N));
+        }
+    }
+
+    [Benchmark]
+    public int DryDB_GetRange_1M()
+    {
+        Span<byte> startKey = stackalloc byte[sizeof(long)];
+        Span<byte> endKey = stackalloc byte[sizeof(long)];
+        System.Buffers.Binary.BinaryPrimitives.WriteInt64LittleEndian(startKey, 500_000);
+        System.Buffers.Binary.BinaryPrimitives.WriteInt64LittleEndian(endKey, 500_099);
+
+        var total = 0;
+        for (var i = 0; i < 100; i++)
+        {
+            var table = database.GetTable("items");
+            using var result = table.GetRange(startKey, endKey);
+            foreach (var value in result)
+            {
+                total += value.Length;
+            }
+        }
+        return total;
+    }
+}

--- a/src/DryDB/BTree/InternalNodeReader.cs
+++ b/src/DryDB/BTree/InternalNodeReader.cs
@@ -12,7 +12,7 @@ namespace DryDB.BTree;
 /// </summary>
 /// <remarks>
 /// </remarks>
-readonly ref struct InternalNodeReader(ReadOnlySpan<byte> page, int entryCount)
+readonly ref struct InternalNodeReader(ReadOnlySpan<byte> page, int entryCount, bool hasKeyDigests)
 {
     [StructLayout(LayoutKind.Explicit, Size = 6, Pack = 1)]
     struct NodeEntryMeta
@@ -24,11 +24,15 @@ readonly ref struct InternalNodeReader(ReadOnlySpan<byte> page, int entryCount)
         public ushort KeyLength;
     }
 
+    static readonly int DigestBase = Unsafe.SizeOf<PageHeader>() + Unsafe.SizeOf<NodeHeader>();
+
 #if NETSTANDARD
     readonly ReadOnlySpan<byte> page = page;
 #else
     readonly ref byte pageReference = ref MemoryMarshal.GetReference(page);
 #endif
+    readonly int metaBase = DigestBase + (hasKeyDigests ? entryCount * sizeof(ulong) : 0);
+    readonly bool hasKeyDigests = hasKeyDigests;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void GetAt(int index, out ReadOnlySpan<byte> key, out PageNumber childPageNumber)
@@ -45,11 +49,18 @@ readonly ref struct InternalNodeReader(ReadOnlySpan<byte> page, int entryCount)
         childPageNumber = Unsafe.ReadUnaligned<PageNumber>(ref ptr);
     }
 
-    public bool TrySearch(ReadOnlySpan<byte> key, IKeyEncoding keyEncoding, out PageNumber childPageNumber)
+    public bool TrySearch(
+        ReadOnlySpan<byte> key,
+        IKeyEncoding keyEncoding,
+        ulong keyDigest,
+        bool hasKeyDigest,
+        out PageNumber childPageNumber)
     {
 #if NETSTANDARD
         ref var pageReference = ref MemoryMarshal.GetReference(page);
 #endif
+        var useDigest = hasKeyDigests && hasKeyDigest;
+
         var min = 0;
         var max = entryCount;
 
@@ -58,11 +69,22 @@ readonly ref struct InternalNodeReader(ReadOnlySpan<byte> page, int entryCount)
         {
             var mid = min + ((max - min) >> 1);
 
-            meta = GetMeta(mid);
-            ref var ptr = ref Unsafe.Add(ref pageReference, meta.PageOffset);
+            int cmp;
+            if (useDigest)
+            {
+                // One contiguous load instead of dereferencing the variable-length key;
+                // only digest ties fall back to the full comparison.
+                var digest = Unsafe.ReadUnaligned<ulong>(
+                    ref Unsafe.Add(ref pageReference, DigestBase + mid * sizeof(ulong)));
+                cmp = digest != keyDigest
+                    ? (digest < keyDigest ? -1 : 1)
+                    : CompareFull(ref pageReference, mid, key, keyEncoding);
+            }
+            else
+            {
+                cmp = CompareFull(ref pageReference, mid, key, keyEncoding);
+            }
 
-            var midKey = MemoryMarshal.CreateReadOnlySpan(ref ptr, meta.KeyLength);
-            var cmp = KeyCompare.Compare(keyEncoding, midKey, key);
             if (cmp <= 0) // upper bounds
             {
                 min = mid + 1;
@@ -80,6 +102,16 @@ readonly ref struct InternalNodeReader(ReadOnlySpan<byte> page, int entryCount)
                 ref pageReference,
                 meta.PageOffset + meta.KeyLength));
         return true;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    int CompareFull(ref byte pageReference, int index, ReadOnlySpan<byte> key, IKeyEncoding keyEncoding)
+    {
+        var meta = GetMeta(index);
+        var entryKey = MemoryMarshal.CreateReadOnlySpan(
+            ref Unsafe.Add(ref pageReference, meta.PageOffset),
+            meta.KeyLength);
+        return KeyCompare.Compare(keyEncoding, entryKey, key);
     }
 
     // for debug purpose
@@ -125,8 +157,7 @@ readonly ref struct InternalNodeReader(ReadOnlySpan<byte> page, int entryCount)
 #endif
         ref var ptr = ref Unsafe.Add(
             ref pageReference,
-            Unsafe.SizeOf<PageHeader>() + Unsafe.SizeOf<NodeHeader>() +
-            index * Unsafe.SizeOf<NodeEntryMeta>());
+            metaBase + index * Unsafe.SizeOf<NodeEntryMeta>());
         return Unsafe.ReadUnaligned<NodeEntryMeta>(ref ptr);
     }
 }

--- a/src/DryDB/BTree/LeafNodeReader.cs
+++ b/src/DryDB/BTree/LeafNodeReader.cs
@@ -12,7 +12,7 @@ namespace DryDB.BTree;
 /// </summary>>
 /// <remarks>
 /// </remarks>
-readonly ref struct LeafNodeReader(ReadOnlySpan<byte> page, int entryCount)
+readonly ref struct LeafNodeReader(ReadOnlySpan<byte> page, int entryCount, bool hasKeyDigests)
 {
     internal const ushort OverflowSentinel = ushort.MaxValue; // 0xFFFF
 
@@ -32,11 +32,15 @@ readonly ref struct LeafNodeReader(ReadOnlySpan<byte> page, int entryCount)
         public ushort ValueLength;
     }
 
+    static readonly int DigestBase = Unsafe.SizeOf<PageHeader>() + Unsafe.SizeOf<NodeHeader>();
+
 #if NETSTANDARD
     readonly ReadOnlySpan<byte> page = page;
 #else
     readonly ref byte pageReference = ref MemoryMarshal.GetReference(page);
 #endif
+    readonly int metaBase = DigestBase + (hasKeyDigests ? entryCount * sizeof(ulong) : 0);
+    readonly bool hasKeyDigests = hasKeyDigests;
 
     public void GetAt(int index, out ReadOnlySpan<byte> key, out ReadOnlySpan<byte> value)
     {
@@ -68,6 +72,8 @@ readonly ref struct LeafNodeReader(ReadOnlySpan<byte> page, int entryCount)
     public bool TryFindValue(
         scoped ReadOnlySpan<byte> key,
         IKeyEncoding keyEncoding,
+        ulong keyDigest,
+        bool hasKeyDigest,
         out int index,
         out int valueOffset,
         out ushort valueLength)
@@ -75,20 +81,34 @@ readonly ref struct LeafNodeReader(ReadOnlySpan<byte> page, int entryCount)
 #if NETSTANDARD
         ref var pageReference = ref MemoryMarshal.GetReference(page);
 #endif
+        var useDigest = hasKeyDigests && hasKeyDigest;
+
         var min = 0;
         var max = entryCount;
 
         while (min < max)
         {
             var midIndex = min + ((max - min) >> 1);
-            var midMeta = GetMeta(midIndex);
 
-            ref var ptr = ref Unsafe.Add(ref pageReference, midMeta.PageOffset);
-            var midKey = MemoryMarshal.CreateReadOnlySpan(ref ptr, midMeta.KeyLength);
+            int compared;
+            if (useDigest)
+            {
+                // One contiguous load instead of dereferencing the variable-length key;
+                // only digest ties fall back to the full comparison.
+                var digest = Unsafe.ReadUnaligned<ulong>(
+                    ref Unsafe.Add(ref pageReference, DigestBase + midIndex * sizeof(ulong)));
+                compared = digest != keyDigest
+                    ? (digest < keyDigest ? -1 : 1)
+                    : CompareFull(ref pageReference, midIndex, key, keyEncoding);
+            }
+            else
+            {
+                compared = CompareFull(ref pageReference, midIndex, key, keyEncoding);
+            }
 
-            var compared = KeyCompare.Compare(keyEncoding, midKey, key);
             if (compared == 0)
             {
+                var midMeta = GetMeta(midIndex);
                 index = midIndex;
                 valueOffset = midMeta.PageOffset + midMeta.KeyLength;
                 valueLength = midMeta.ValueLength;
@@ -114,11 +134,14 @@ readonly ref struct LeafNodeReader(ReadOnlySpan<byte> page, int entryCount)
         ReadOnlySpan<byte> key,
         SearchOperator op,
         IKeyEncoding keyEncoding,
+        ulong keyDigest,
+        bool hasKeyDigest,
         out int index)
     {
 #if  NETSTANDARD
         ref var pageReference = ref MemoryMarshal.GetReference(page);
 #endif
+        var useDigest = hasKeyDigests && hasKeyDigest;
 
         var min = 0;
         var max = entryCount;
@@ -127,12 +150,21 @@ readonly ref struct LeafNodeReader(ReadOnlySpan<byte> page, int entryCount)
         while (min < max)
         {
             var midIndex = min + ((max - min) >> 1);
-            var midMeta = GetMeta(midIndex);
 
-            ref var ptr = ref Unsafe.Add(ref pageReference, midMeta.PageOffset);
-            var midKey = MemoryMarshal.CreateReadOnlySpan(ref ptr, midMeta.KeyLength);
+            int compared;
+            if (useDigest)
+            {
+                var digest = Unsafe.ReadUnaligned<ulong>(
+                    ref Unsafe.Add(ref pageReference, DigestBase + midIndex * sizeof(ulong)));
+                compared = digest != keyDigest
+                    ? (digest < keyDigest ? -1 : 1)
+                    : CompareFull(ref pageReference, midIndex, key, keyEncoding);
+            }
+            else
+            {
+                compared = CompareFull(ref pageReference, midIndex, key, keyEncoding);
+            }
 
-            var compared = KeyCompare.Compare(keyEncoding, midKey, key);
             switch (op)
             {
                 case SearchOperator.Equal:
@@ -189,10 +221,7 @@ readonly ref struct LeafNodeReader(ReadOnlySpan<byte> page, int entryCount)
             case SearchOperator.Equal:
                 if (min < max)
                 {
-                    var meta = GetMeta(min);
-                    ref var ptr = ref Unsafe.Add(ref pageReference, meta.PageOffset);
-                    var foundKey = MemoryMarshal.CreateReadOnlySpan(ref ptr, meta.KeyLength);
-                    if (KeyCompare.Compare(keyEncoding, foundKey, key) == 0)
+                    if (CompareFull(ref pageReference, min, key, keyEncoding) == 0)
                     {
                         index = min;
                         return true;
@@ -215,6 +244,16 @@ readonly ref struct LeafNodeReader(ReadOnlySpan<byte> page, int entryCount)
                 index = default;
                 return false;
         }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    int CompareFull(ref byte pageReference, int index, ReadOnlySpan<byte> key, IKeyEncoding keyEncoding)
+    {
+        var meta = GetMeta(index);
+        var entryKey = MemoryMarshal.CreateReadOnlySpan(
+            ref Unsafe.Add(ref pageReference, meta.PageOffset),
+            meta.KeyLength);
+        return KeyCompare.Compare(keyEncoding, entryKey, key);
     }
 
     // for debug purpose
@@ -261,8 +300,7 @@ readonly ref struct LeafNodeReader(ReadOnlySpan<byte> page, int entryCount)
 #endif
         ref var ptr = ref Unsafe.Add(
             ref pageReference,
-            Unsafe.SizeOf<PageHeader>() + Unsafe.SizeOf<NodeHeader>() +
-            index * Unsafe.SizeOf<NodeEntryMeta>());
+            metaBase + index * Unsafe.SizeOf<NodeEntryMeta>());
         return Unsafe.ReadUnaligned<NodeEntryMeta>(ref ptr);
     }
 }

--- a/src/DryDB/BTree/NodeHeader.cs
+++ b/src/DryDB/BTree/NodeHeader.cs
@@ -10,6 +10,19 @@ enum NodeKind
     Internal = 1,
 }
 
+static class NodeFlags
+{
+    // The low byte of the on-disk kind field is the NodeKind; the upper bits carry
+    // per-page format flags. Old files have no flags set and keep the old layout.
+    public const int KindMask = 0xFF;
+
+    /// <summary>
+    /// A contiguous array of 8-byte key digests sits between the node header and the
+    /// entry metadata.
+    /// </summary>
+    public const int HasKeyDigests = 1 << 8;
+}
+
 static class NodeHeaderExtensions
 {
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -30,8 +43,21 @@ static class NodeHeaderExtensions
 [StructLayout(LayoutKind.Explicit, Pack = 1)]
 unsafe struct NodeHeader
 {
+    // Raw on-disk kind field: low byte is the NodeKind, upper bits are NodeFlags.
     [FieldOffset(0)]
     public NodeKind Kind;
+
+    public NodeKind NodeKind
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => (NodeKind)((int)Kind & NodeFlags.KindMask);
+    }
+
+    public bool HasKeyDigests
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => ((int)Kind & NodeFlags.HasKeyDigests) != 0;
+    }
 
     [FieldOffset(4)]
     public fixed byte EntryCountBytes[4];

--- a/src/DryDB/BTree/TreeBuilder.cs
+++ b/src/DryDB/BTree/TreeBuilder.cs
@@ -55,6 +55,7 @@ static class TreeBuilder
         int pageSize,
         KeyValueList keyValues,
         IReadOnlyList<IPageFilter>? pageFilters = null,
+        bool keyDigests = true,
         CancellationToken cancellationToken = default)
     {
         if (pageSize < PageHeaderSize + 32)
@@ -64,9 +65,12 @@ static class TreeBuilder
 
         var wroteValuePointers = new List<PageRef>(keyValues.Count);
 
-        // When the encoding provides order-preserving digests, every node carries a
-        // contiguous 8-byte digest per entry, searched instead of the scattered keys.
-        var digestEncoding = keyValues.KeyEncoding.SupportsKeyDigest ? keyValues.KeyEncoding : null;
+        // When enabled and the encoding provides order-preserving digests, every node
+        // carries a contiguous 8-byte digest per entry, searched instead of the
+        // scattered keys.
+        var digestEncoding = keyDigests && keyValues.KeyEncoding.SupportsKeyDigest
+            ? keyValues.KeyEncoding
+            : null;
         var digestSize = digestEncoding != null ? sizeof(ulong) : 0;
 
         var nodes = new List<NodeEntry> { new(pageSize) };

--- a/src/DryDB/BTree/TreeBuilder.cs
+++ b/src/DryDB/BTree/TreeBuilder.cs
@@ -64,6 +64,11 @@ static class TreeBuilder
 
         var wroteValuePointers = new List<PageRef>(keyValues.Count);
 
+        // When the encoding provides order-preserving digests, every node carries a
+        // contiguous 8-byte digest per entry, searched instead of the scattered keys.
+        var digestEncoding = keyValues.KeyEncoding.SupportsKeyDigest ? keyValues.KeyEncoding : null;
+        var digestSize = digestEncoding != null ? sizeof(ulong) : 0;
+
         var nodes = new List<NodeEntry> { new(pageSize) };
         nodes[0].Reset();
 
@@ -76,17 +81,17 @@ static class TreeBuilder
             }
 
             var isOverflow = false;
-            var inlineNeeds = PageHeaderSize + (leaf.EntryCount + 1) * (sizeof(int) + sizeof(ushort) * 2) +
+            var inlineNeeds = PageHeaderSize + (leaf.EntryCount + 1) * (sizeof(int) + sizeof(ushort) * 2 + digestSize) +
                         leaf.KeyValueBufferOffset + key.Length + value.Length;
             if (inlineNeeds > pageSize)
             {
                 // Check if it fits as overflow (key + 8-byte PageNumber.Value)
-                var overflowNeeds = PageHeaderSize + (leaf.EntryCount + 1) * (sizeof(int) + sizeof(ushort) * 2) +
+                var overflowNeeds = PageHeaderSize + (leaf.EntryCount + 1) * (sizeof(int) + sizeof(ushort) * 2 + digestSize) +
                             leaf.KeyValueBufferOffset + key.Length + sizeof(long);
                 if (overflowNeeds > pageSize)
                 {
                     // Current page is full even for overflow; rotate
-                    await RotatePageAsync(outStream, nodes, 0, true, wroteValuePointers, pageFilters, cancellationToken)
+                    await RotatePageAsync(outStream, nodes, 0, true, wroteValuePointers, digestEncoding, pageFilters, cancellationToken)
                         .ConfigureAwait(false);
                     if (nodes[0].EntryCount <= 0)
                     {
@@ -96,7 +101,7 @@ static class TreeBuilder
                 }
 
                 // Recalculate after potential rotation
-                inlineNeeds = PageHeaderSize + (leaf.EntryCount + 1) * (sizeof(int) + sizeof(ushort) * 2) +
+                inlineNeeds = PageHeaderSize + (leaf.EntryCount + 1) * (sizeof(int) + sizeof(ushort) * 2 + digestSize) +
                             leaf.KeyValueBufferOffset + key.Length + value.Length;
                 if (inlineNeeds > pageSize)
                 {
@@ -154,7 +159,7 @@ static class TreeBuilder
             {
                 if (nodes[level].EntryCount > 0)
                 {
-                    await RotatePageAsync(outStream, nodes, level, true, wroteValuePointers, pageFilters, cancellationToken).ConfigureAwait(false);
+                    await RotatePageAsync(outStream, nodes, level, true, wroteValuePointers, digestEncoding, pageFilters, cancellationToken).ConfigureAwait(false);
                     anyFlushed = true;
                 }
             }
@@ -164,7 +169,7 @@ static class TreeBuilder
         // Write the root (top level)
         if (nodes[^1].EntryCount > 0)
         {
-            await RotatePageAsync(outStream, nodes, nodes.Count - 1, false, wroteValuePointers, pageFilters, cancellationToken).ConfigureAwait(false);
+            await RotatePageAsync(outStream, nodes, nodes.Count - 1, false, wroteValuePointers, digestEncoding, pageFilters, cancellationToken).ConfigureAwait(false);
         }
 
         var rootPageNumber = nodes[^1].PrevNodeStartPageNumber; // latest root
@@ -220,6 +225,7 @@ static class TreeBuilder
         int level,
         bool promote,
         List<PageRef> wroteValueRefs,
+        IKeyEncoding? digestEncoding,
         IReadOnlyList<IPageFilter>? pageFilters = null,
         CancellationToken cancellationToken = default)
     {
@@ -229,13 +235,13 @@ static class TreeBuilder
         var kind = level == 0 ? NodeKind.Leaf : NodeKind.Internal;
         var nodeHeader = new NodeHeader
         {
-            Kind = kind,
+            Kind = (NodeKind)((int)kind | (digestEncoding != null ? NodeFlags.HasKeyDigests : 0)),
             EntryCount = currentNode.EntryCount,
             LeftSiblingPageNumber = currentNode.PrevNodeStartPageNumber,
             RightSiblingPageNumber = PageNumber.Empty
         };
 
-        await FlushPageAsync(outStream, nodeHeader, currentNode, wroteValueRefs, pageFilters, cancellationToken)
+        await FlushPageAsync(outStream, nodeHeader, currentNode, wroteValueRefs, digestEncoding, pageFilters, cancellationToken)
             .ConfigureAwait(false);
 
         // Patch RightSiblingPosition
@@ -279,11 +285,12 @@ static class TreeBuilder
             parent.FirstKey = sepKey;
         }
 
-        var needs = PageHeaderSize + (parent.EntryCount + 1) * (sizeof(int) + sizeof(ushort)) +
+        var digestSize = digestEncoding != null ? sizeof(ulong) : 0;
+        var needs = PageHeaderSize + (parent.EntryCount + 1) * (sizeof(int) + sizeof(ushort) + digestSize) +
                     parent.KeyValueBufferOffset + sepKey.Length + sizeof(long);
         if (needs > parent.PageSize)
         {
-            await RotatePageAsync(outStream, nodeEntries, parentLevel, true, wroteValueRefs, pageFilters, cancellationToken)
+            await RotatePageAsync(outStream, nodeEntries, parentLevel, true, wroteValueRefs, digestEncoding, pageFilters, cancellationToken)
                 .ConfigureAwait(false);
             if (parent.EntryCount == 0) parent.FirstKey = sepKey; // first key of new page
         }
@@ -313,13 +320,16 @@ static class TreeBuilder
         NodeHeader nodeHeader,
         NodeEntry node,
         List<PageRef> wroteValueRefs,
+        IKeyEncoding? digestEncoding,
         IReadOnlyList<IPageFilter>? filters,
         CancellationToken cancellationToken = default)
     {
         var currentPageNumber = new PageNumber(outStream.Position);
 
+        var digestSize = digestEncoding != null ? sizeof(ulong) : 0;
         var pageLength = PageHeaderSize +
-                         node.EntryCount * (nodeHeader.Kind == NodeKind.Leaf
+                         node.EntryCount * digestSize +
+                         node.EntryCount * (nodeHeader.NodeKind == NodeKind.Leaf
                              ? sizeof(int) + sizeof(ushort) * 2
                              : sizeof(int) + sizeof(ushort)) +
                          node.KeyValueBufferOffset;
@@ -338,18 +348,33 @@ static class TreeBuilder
         Unsafe.WriteUnaligned(ref ptr, nodeHeader);
         ptr = ref Unsafe.Add(ref ptr, Unsafe.SizeOf<NodeHeader>());
 
+        // write key digests (keys sit at running offsets in KeyValueBuffer)
+        if (digestEncoding != null)
+        {
+            var keyOffset = 0;
+            for (var i = 0; i < node.KeyValueSizes.Count; i++)
+            {
+                var (keyLength, valueLength) = node.KeyValueSizes[i];
+                var digest = digestEncoding.GetKeyDigest(
+                    node.KeyValueBuffer.AsSpan(keyOffset, keyLength));
+                Unsafe.WriteUnaligned(ref ptr, digest);
+                ptr = ref Unsafe.Add(ref ptr, sizeof(ulong));
+                keyOffset += keyLength + valueLength;
+            }
+        }
+
         // write meta(s)
-        var metaSize = nodeHeader.Kind == NodeKind.Leaf
+        var metaSize = nodeHeader.NodeKind == NodeKind.Leaf
             ? sizeof(int) + sizeof(ushort) * 2
             : sizeof(int) + sizeof(ushort);
 
-        var payloadOffset = PageHeaderSize + node.EntryCount * metaSize;
+        var payloadOffset = PageHeaderSize + node.EntryCount * digestSize + node.EntryCount * metaSize;
 
         for (var i = 0; i < node.KeyValueSizes.Count; i++)
         {
             var (keyLength, valueLength) = node.KeyValueSizes[i];
 
-            if (nodeHeader.Kind == NodeKind.Leaf)
+            if (nodeHeader.NodeKind == NodeKind.Leaf)
             {
                 var overflowRef = node.OverflowPageRefs[i];
                 if (overflowRef.HasValue)
@@ -368,7 +393,7 @@ static class TreeBuilder
             Unsafe.WriteUnaligned(ref ptr, (ushort)keyLength);
             ptr = ref Unsafe.Add(ref ptr, sizeof(ushort));
 
-            if (nodeHeader.Kind == NodeKind.Leaf)
+            if (nodeHeader.NodeKind == NodeKind.Leaf)
             {
                 var overflowRef = node.OverflowPageRefs[i];
                 // variable length value (sentinel for overflow)

--- a/src/DryDB/BTree/TreeWalker.cs
+++ b/src/DryDB/BTree/TreeWalker.cs
@@ -21,6 +21,7 @@ class TreeWalker
     public IKeyEncoding KeyEncoding { get; }
 
     readonly IKeyEncoding comparer;
+    readonly bool supportsKeyDigest;
 
     // The root page is touched by every lookup. Keep one retained reference here so the
     // hot path can skip the cache lookup + refcount traffic for it. The pin lives until
@@ -72,6 +73,19 @@ class TreeWalker
             Int64LittleEndianEncoding => Int64LittleEndianEncoding.Instance,
             _ => keyEncoding
         };
+        supportsKeyDigest = comparer.SupportsKeyDigest;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    bool TryGetKeyDigest(scoped ReadOnlySpan<byte> key, out ulong digest)
+    {
+        if (supportsKeyDigest && key.Length > 0)
+        {
+            digest = comparer.GetKeyDigest(key);
+            return true;
+        }
+        digest = 0;
+        return false;
     }
 
     /// <summary>
@@ -171,16 +185,17 @@ class TreeWalker
 
     public SingleValueResult Get(ReadOnlySpan<byte> key)
     {
+        var hasKeyDigest = TryGetKeyDigest(key, out var keyDigest);
         var pageNumber = RootPageNumber;
         while (true)
         {
             var lease = GetPage(pageNumber);
             var pageSpan = lease.Page.Memory.Span;
             var header = NodeHeader.Parse(pageSpan);
-            if (header.Kind == NodeKind.Internal)
+            if (header.NodeKind == NodeKind.Internal)
             {
-                var internalNode = new InternalNodeReader(pageSpan, header.EntryCount);
-                var descended = internalNode.TrySearch(key, comparer, out pageNumber);
+                var internalNode = new InternalNodeReader(pageSpan, header.EntryCount, header.HasKeyDigests);
+                var descended = internalNode.TrySearch(key, comparer, keyDigest, hasKeyDigest, out pageNumber);
                 lease.Release();
                 if (!descended)
                 {
@@ -189,8 +204,8 @@ class TreeWalker
             }
             else // Leaf
             {
-                var leafNode = new LeafNodeReader(pageSpan, header.EntryCount);
-                if (leafNode.TryFindValue(key, comparer, out _, out var valueOffset, out var valueLength))
+                var leafNode = new LeafNodeReader(pageSpan, header.EntryCount, header.HasKeyDigests);
+                if (leafNode.TryFindValue(key, comparer, keyDigest, hasKeyDigest, out _, out var valueOffset, out var valueLength))
                 {
                     if (LeafNodeReader.IsOverflow(valueLength))
                     {
@@ -226,6 +241,7 @@ class TreeWalker
     /// </summary>
     internal bool TryGetFromCache(scoped ReadOnlySpan<byte> key, out SingleValueResult result)
     {
+        var hasKeyDigest = TryGetKeyDigest(key, out var keyDigest);
         var pageNumber = RootPageNumber;
         while (true)
         {
@@ -237,10 +253,10 @@ class TreeWalker
 
             var pageSpan = lease.Page.Memory.Span;
             var header = NodeHeader.Parse(pageSpan);
-            if (header.Kind == NodeKind.Internal)
+            if (header.NodeKind == NodeKind.Internal)
             {
-                var descended = new InternalNodeReader(pageSpan, header.EntryCount)
-                    .TrySearch(key, comparer, out pageNumber);
+                var descended = new InternalNodeReader(pageSpan, header.EntryCount, header.HasKeyDigests)
+                    .TrySearch(key, comparer, keyDigest, hasKeyDigest, out pageNumber);
                 lease.Release();
                 if (!descended)
                 {
@@ -250,8 +266,8 @@ class TreeWalker
             }
             else // Leaf
             {
-                var leafNode = new LeafNodeReader(pageSpan, header.EntryCount);
-                if (leafNode.TryFindValue(key, comparer, out _, out var valueOffset, out var valueLength))
+                var leafNode = new LeafNodeReader(pageSpan, header.EntryCount, header.HasKeyDigests);
+                if (leafNode.TryFindValue(key, comparer, keyDigest, hasKeyDigest, out _, out var valueOffset, out var valueLength))
                 {
                     if (LeafNodeReader.IsOverflow(valueLength))
                     {
@@ -284,15 +300,16 @@ class TreeWalker
         ReadOnlyMemory<byte> key,
         CancellationToken cancellationToken)
     {
+        var hasKeyDigest = TryGetKeyDigest(key.Span, out var keyDigest);
         var pageNumber = RootPageNumber;
         while (true)
         {
             var lease = await GetPageAsync(pageNumber, cancellationToken).ConfigureAwait(false);
             var header = NodeHeader.Parse(lease.Page.Memory.Span);
-            if (header.Kind == NodeKind.Internal)
+            if (header.NodeKind == NodeKind.Internal)
             {
-                var descended = new InternalNodeReader(lease.Page.Memory.Span, header.EntryCount)
-                    .TrySearch(key.Span, comparer, out pageNumber);
+                var descended = new InternalNodeReader(lease.Page.Memory.Span, header.EntryCount, header.HasKeyDigests)
+                    .TrySearch(key.Span, comparer, keyDigest, hasKeyDigest, out pageNumber);
                 lease.Release();
                 if (!descended)
                 {
@@ -301,8 +318,8 @@ class TreeWalker
             }
             else // Leaf
             {
-                if (new LeafNodeReader(lease.Page.Memory.Span, header.EntryCount)
-                    .TryFindValue(key.Span, comparer, out _, out var valueOffset, out var valueLength))
+                if (new LeafNodeReader(lease.Page.Memory.Span, header.EntryCount, header.HasKeyDigests)
+                    .TryFindValue(key.Span, comparer, keyDigest, hasKeyDigest, out _, out var valueOffset, out var valueLength))
                 {
                     if (LeafNodeReader.IsOverflow(valueLength))
                     {
@@ -333,16 +350,17 @@ class TreeWalker
         out IPageEntry page,
         out int index)
     {
+        var hasKeyDigest = TryGetKeyDigest(key, out var keyDigest);
         var pageNumber = RootPageNumber;
         while (true)
         {
             var lease = GetPage(pageNumber);
             var pageSpan = lease.Page.Memory.Span;
             var header = NodeHeader.Parse(pageSpan);
-            if (header.Kind == NodeKind.Internal)
+            if (header.NodeKind == NodeKind.Internal)
             {
-                var internalNode = new InternalNodeReader(pageSpan, header.EntryCount);
-                var descended = internalNode.TrySearch(key, comparer, out pageNumber);
+                var internalNode = new InternalNodeReader(pageSpan, header.EntryCount, header.HasKeyDigests);
+                var descended = internalNode.TrySearch(key, comparer, keyDigest, hasKeyDigest, out pageNumber);
                 lease.Release();
                 if (!descended)
                 {
@@ -353,10 +371,22 @@ class TreeWalker
             }
             else // Leaf
             {
-                var leafNode = new LeafNodeReader(pageSpan, header.EntryCount);
-                if (leafNode.TrySearch(key, op, comparer, out index))
+                var leafNode = new LeafNodeReader(pageSpan, header.EntryCount, header.HasKeyDigests);
+                if (leafNode.TrySearch(key, op, comparer, keyDigest, hasKeyDigest, out index))
                 {
                     page = lease.Take();
+                    return true;
+                }
+
+                // A bound miss on the leaf means every entry is below the bound. For
+                // LowerBound/UpperBound the answer, if it exists, is the first entry
+                // of the right sibling.
+                if (op != SearchOperator.Equal && !header.RightSiblingPageNumber.IsEmpty)
+                {
+                    var siblingPageNumber = header.RightSiblingPageNumber;
+                    lease.Release();
+                    page = PageCache.GetOrLoad(siblingPageNumber);
+                    index = 0;
                     return true;
                 }
 
@@ -373,15 +403,16 @@ class TreeWalker
         SearchOperator op,
         CancellationToken cancellationToken)
     {
+        var hasKeyDigest = TryGetKeyDigest(key.Span, out var keyDigest);
         var pageNumber = RootPageNumber;
         while (true)
         {
             var lease = await GetPageAsync(pageNumber, cancellationToken).ConfigureAwait(false);
             var header = NodeHeader.Parse(lease.Page.Memory.Span);
-            if (header.Kind == NodeKind.Internal)
+            if (header.NodeKind == NodeKind.Internal)
             {
-                var descended = new InternalNodeReader(lease.Page.Memory.Span, header.EntryCount)
-                    .TrySearch(key.Span, comparer, out pageNumber);
+                var descended = new InternalNodeReader(lease.Page.Memory.Span, header.EntryCount, header.HasKeyDigests)
+                    .TrySearch(key.Span, comparer, keyDigest, hasKeyDigest, out pageNumber);
                 lease.Release();
                 if (!descended)
                 {
@@ -390,10 +421,22 @@ class TreeWalker
             }
             else // Leaf
             {
-                if (new LeafNodeReader(lease.Page.Memory.Span, header.EntryCount)
-                    .TrySearch(key.Span, op, comparer, out var index))
+                if (new LeafNodeReader(lease.Page.Memory.Span, header.EntryCount, header.HasKeyDigests)
+                    .TrySearch(key.Span, op, comparer, keyDigest, hasKeyDigest, out var index))
                 {
                     return (lease.Take(), index);
+                }
+
+                // A bound miss on the leaf means every entry is below the bound. For
+                // LowerBound/UpperBound the answer, if it exists, is the first entry
+                // of the right sibling.
+                if (op != SearchOperator.Equal && !header.RightSiblingPageNumber.IsEmpty)
+                {
+                    var siblingPageNumber = header.RightSiblingPageNumber;
+                    lease.Release();
+                    var sibling = await PageCache.GetOrLoadAsync(siblingPageNumber, cancellationToken)
+                        .ConfigureAwait(false);
+                    return (sibling, 0);
                 }
 
                 lease.Release();
@@ -445,6 +488,7 @@ class TreeWalker
             return RangeResult.Empty;
         }
 
+        var hasEndKeyDigest = TryGetKeyDigest(endKey, out var endKeyDigest);
         var result = RangeResult.Rent();
 
         while (true)
@@ -454,12 +498,12 @@ class TreeWalker
             {
                 var pageSpan = currentPage.Memory.Span;
                 var header = NodeHeader.Parse(pageSpan);
-                if (header.Kind != NodeKind.Leaf)
+                if (header.NodeKind != NodeKind.Leaf)
                 {
                     throw new InvalidOperationException("Invalid node kind");
                 }
 
-                var leafNode = new LeafNodeReader(pageSpan, header.EntryCount);
+                var leafNode = new LeafNodeReader(pageSpan, header.EntryCount, header.HasKeyDigests);
 
                 // Entries within a leaf are sorted: locate the end bound with one binary
                 // search instead of comparing every entry.
@@ -468,7 +512,7 @@ class TreeWalker
                 if (!endKey.IsEmpty)
                 {
                     var op = endKeyExclusive ? SearchOperator.LowerBound : SearchOperator.UpperBound;
-                    if (leafNode.TrySearch(endKey, op, comparer, out var boundIndex))
+                    if (leafNode.TrySearch(endKey, op, comparer, endKeyDigest, hasEndKeyDigest, out var boundIndex))
                     {
                         stopIndex = boundIndex;
                         endsInThisLeaf = true;
@@ -522,6 +566,7 @@ class TreeWalker
 
         var page = start.Value.Page;
         var entryIndex = start.Value.EntryIndex;
+        var hasStartKeyDigest = TryGetKeyDigest(startKey, out var startKeyDigest);
         var result = RangeResult.Rent();
 
         while (true)
@@ -531,12 +576,12 @@ class TreeWalker
             {
                 var pageSpan = currentPage.Memory.Span;
                 var header = NodeHeader.Parse(pageSpan);
-                if (header.Kind != NodeKind.Leaf)
+                if (header.NodeKind != NodeKind.Leaf)
                 {
                     throw new InvalidOperationException("Invalid node kind");
                 }
 
-                var leafNode = new LeafNodeReader(pageSpan, header.EntryCount);
+                var leafNode = new LeafNodeReader(pageSpan, header.EntryCount, header.HasKeyDigests);
 
                 // Entries within a leaf are sorted: locate the start bound with one
                 // binary search instead of comparing every entry.
@@ -544,7 +589,7 @@ class TreeWalker
                 if (!startKey.IsEmpty)
                 {
                     var op = startKeyExclusive ? SearchOperator.UpperBound : SearchOperator.LowerBound;
-                    if (!leafNode.TrySearch(startKey, op, comparer, out boundIndex))
+                    if (!leafNode.TrySearch(startKey, op, comparer, startKeyDigest, hasStartKeyDigest, out boundIndex))
                     {
                         // Everything in (and left of) this leaf is below the start bound.
                         return result;
@@ -633,6 +678,7 @@ class TreeWalker
             page = startPage;
         }
 
+        var hasEndKeyDigest = TryGetKeyDigest(endKey.Span, out var endKeyDigest);
         var result = RangeResult.Rent();
 
         while (true)
@@ -641,7 +687,7 @@ class TreeWalker
             try
             {
                 var header = NodeHeader.Parse(currentPage.Memory.Span);
-                if (header.Kind != NodeKind.Leaf)
+                if (header.NodeKind != NodeKind.Leaf)
                 {
                     throw new InvalidOperationException("Invalid node kind");
                 }
@@ -653,8 +699,8 @@ class TreeWalker
                 if (!endKey.IsEmpty)
                 {
                     var op = endKeyExclusive ? SearchOperator.LowerBound : SearchOperator.UpperBound;
-                    if (new LeafNodeReader(currentPage.Memory.Span, header.EntryCount)
-                        .TrySearch(endKey.Span, op, comparer, out var boundIndex))
+                    if (new LeafNodeReader(currentPage.Memory.Span, header.EntryCount, header.HasKeyDigests)
+                        .TrySearch(endKey.Span, op, comparer, endKeyDigest, hasEndKeyDigest, out var boundIndex))
                     {
                         stopIndex = boundIndex;
                         endsInThisLeaf = true;
@@ -665,7 +711,7 @@ class TreeWalker
                 {
                     int pageOffset;
                     ushort keyLength, valueLength;
-                    new LeafNodeReader(currentPage.Memory.Span, header.EntryCount)
+                    new LeafNodeReader(currentPage.Memory.Span, header.EntryCount, header.HasKeyDigests)
                         .GetAt(entryIndex, out pageOffset, out keyLength, out valueLength);
 
                     if (LeafNodeReader.IsOverflow(valueLength))
@@ -715,6 +761,7 @@ class TreeWalker
 
         var page = start.Value.Page;
         var entryIndex = start.Value.EntryIndex;
+        var hasStartKeyDigest = TryGetKeyDigest(startKey.Span, out var startKeyDigest);
         var result = RangeResult.Rent();
 
         while (true)
@@ -723,7 +770,7 @@ class TreeWalker
             try
             {
                 var header = NodeHeader.Parse(currentPage.Memory.Span);
-                if (header.Kind != NodeKind.Leaf)
+                if (header.NodeKind != NodeKind.Leaf)
                 {
                     throw new InvalidOperationException("Invalid node kind");
                 }
@@ -734,8 +781,8 @@ class TreeWalker
                 if (!startKey.IsEmpty)
                 {
                     var op = startKeyExclusive ? SearchOperator.UpperBound : SearchOperator.LowerBound;
-                    if (!new LeafNodeReader(currentPage.Memory.Span, header.EntryCount)
-                        .TrySearch(startKey.Span, op, comparer, out boundIndex))
+                    if (!new LeafNodeReader(currentPage.Memory.Span, header.EntryCount, header.HasKeyDigests)
+                        .TrySearch(startKey.Span, op, comparer, startKeyDigest, hasStartKeyDigest, out boundIndex))
                     {
                         // Everything in (and left of) this leaf is below the start bound.
                         return result;
@@ -746,7 +793,7 @@ class TreeWalker
                 {
                     int pageOffset;
                     ushort keyLength, valueLength;
-                    new LeafNodeReader(currentPage.Memory.Span, header.EntryCount)
+                    new LeafNodeReader(currentPage.Memory.Span, header.EntryCount, header.HasKeyDigests)
                         .GetAt(entryIndex, out pageOffset, out keyLength, out valueLength);
 
                     if (LeafNodeReader.IsOverflow(valueLength))
@@ -812,6 +859,8 @@ class TreeWalker
             return 0;
         }
 
+        var hasEndKeyDigest = TryGetKeyDigest(endKey, out var endKeyDigest);
+
         var count = 0;
 
         while (true)
@@ -824,7 +873,7 @@ class TreeWalker
             {
                 var pageSpan = currentPage.Memory.Span;
                 var header = NodeHeader.Parse(pageSpan);
-                if (header.Kind != NodeKind.Leaf)
+                if (header.NodeKind != NodeKind.Leaf)
                 {
                     throw new InvalidOperationException("Invalid node kind");
                 }
@@ -833,9 +882,9 @@ class TreeWalker
                 // search instead of comparing every entry.
                 if (!endKey.IsEmpty)
                 {
-                    var leafNode = new LeafNodeReader(pageSpan, header.EntryCount);
+                    var leafNode = new LeafNodeReader(pageSpan, header.EntryCount, header.HasKeyDigests);
                     var op = endKeyExclusive ? SearchOperator.LowerBound : SearchOperator.UpperBound;
-                    if (leafNode.TrySearch(endKey, op, comparer, out var boundIndex))
+                    if (leafNode.TrySearch(endKey, op, comparer, endKeyDigest, hasEndKeyDigest, out var boundIndex))
                     {
                         // The range ends inside this leaf.
                         return count + Math.Max(0, boundIndex - entryIndex);
@@ -895,6 +944,8 @@ class TreeWalker
             page = startPage;
         }
 
+        var hasEndKeyDigest = TryGetKeyDigest(endKey.Span, out var endKeyDigest);
+
         var count = 0;
 
         while (true)
@@ -907,7 +958,7 @@ class TreeWalker
             {
                 var pageSpan = currentPage.Memory.Span;
                 var header = NodeHeader.Parse(pageSpan);
-                if (header.Kind != NodeKind.Leaf)
+                if (header.NodeKind != NodeKind.Leaf)
                 {
                     throw new InvalidOperationException("Invalid node kind");
                 }
@@ -916,9 +967,9 @@ class TreeWalker
                 // search instead of comparing every entry.
                 if (!endKey.IsEmpty)
                 {
-                    var leafNode = new LeafNodeReader(pageSpan, header.EntryCount);
+                    var leafNode = new LeafNodeReader(pageSpan, header.EntryCount, header.HasKeyDigests);
                     var op = endKeyExclusive ? SearchOperator.LowerBound : SearchOperator.UpperBound;
-                    if (leafNode.TrySearch(endKey.Span, op, comparer, out var boundIndex))
+                    if (leafNode.TrySearch(endKey.Span, op, comparer, endKeyDigest, hasEndKeyDigest, out var boundIndex))
                     {
                         // The range ends inside this leaf.
                         return count + Math.Max(0, boundIndex - entryIndex);
@@ -983,7 +1034,7 @@ class TreeWalker
         }
 
         var (page, entryIndex) = minLeaf.Value;
-        var leafNode = new LeafNodeReader(page.Memory.Span, NodeHeader.Parse(page.Memory.Span).EntryCount);
+        var leafNode = new LeafNodeReader(page.Memory.Span, NodeHeader.Parse(page.Memory.Span).EntryCount, NodeHeader.Parse(page.Memory.Span).HasKeyDigests);
         leafNode.GetAt(entryIndex, out var pageOffset, out var keyLength, out var valueLength);
 
         if (LeafNodeReader.IsOverflow(valueLength))
@@ -1006,7 +1057,7 @@ class TreeWalker
         }
 
         var (page, entryIndex) = maxLeaf.Value;
-        var leafNode = new LeafNodeReader(page.Memory.Span, NodeHeader.Parse(page.Memory.Span).EntryCount);
+        var leafNode = new LeafNodeReader(page.Memory.Span, NodeHeader.Parse(page.Memory.Span).EntryCount, NodeHeader.Parse(page.Memory.Span).HasKeyDigests);
         leafNode.GetAt(entryIndex, out var pageOffset, out var keyLength, out var valueLength);
 
         if (LeafNodeReader.IsOverflow(valueLength))
@@ -1028,7 +1079,7 @@ class TreeWalker
             var lease = GetPage(pageNumber);
             var pageSpan = lease.Page.Memory.Span;
             var header = NodeHeader.Parse(pageSpan);
-            if (header.Kind == NodeKind.Internal)
+            if (header.NodeKind == NodeKind.Internal)
             {
                 if (header.EntryCount <= 0)
                 {
@@ -1036,7 +1087,7 @@ class TreeWalker
                     return null;
                 }
 
-                var internalNode = new InternalNodeReader(pageSpan, header.EntryCount);
+                var internalNode = new InternalNodeReader(pageSpan, header.EntryCount, header.HasKeyDigests);
                 internalNode.GetAt(0, out _, out pageNumber);
                 lease.Release();
             }
@@ -1060,7 +1111,7 @@ class TreeWalker
             var lease = GetPage(pageNumber);
             var pageSpan = lease.Page.Memory.Span;
             var header = NodeHeader.Parse(pageSpan);
-            if (header.Kind == NodeKind.Internal)
+            if (header.NodeKind == NodeKind.Internal)
             {
                 if (header.EntryCount <= 0)
                 {
@@ -1068,7 +1119,7 @@ class TreeWalker
                     return null;
                 }
 
-                var internalNode = new InternalNodeReader(pageSpan, header.EntryCount);
+                var internalNode = new InternalNodeReader(pageSpan, header.EntryCount, header.HasKeyDigests);
                 internalNode.GetAt(header.EntryCount - 1, out _, out pageNumber);
                 lease.Release();
             }

--- a/src/DryDB/DatabaseBuilder.cs
+++ b/src/DryDB/DatabaseBuilder.cs
@@ -174,7 +174,9 @@ public class DatabaseBuilder : IDisposable
             Header.MagicBytesValue.CopyTo(new Span<byte>(header.MagicBytes, Header.MagicBytesValue.Length));
         }
         header.MajorVersion = 1;
-        header.MinorVersion = 0;
+        // 1.1: B+Tree nodes may carry per-entry key digest arrays (flagged per page in
+        // the node header's kind field). 1.0 readers cannot parse such pages.
+        header.MinorVersion = 1;
         header.PageFilterCount = (ushort)(filterOptions?.Filters.Count ?? 0);
         header.PageSize = PageSize;
         header.TableCount = (ushort)tableBuilders.Count;

--- a/src/DryDB/DatabaseBuilder.cs
+++ b/src/DryDB/DatabaseBuilder.cs
@@ -137,6 +137,15 @@ public class DatabaseBuilder : IDisposable
 {
     public int PageSize { get; set; } = 4096;
 
+    /// <summary>
+    /// Store an order-preserving 8-byte digest per entry in every B+Tree node, which
+    /// speeds up key searches (~20-30% for cache-resident reads) at the cost of 8 bytes
+    /// per entry of file size. Encodings without digest support (e.g. UUIDv7 or custom
+    /// encodings) always use the plain layout regardless of this setting.
+    /// Disable to produce files byte-compatible with DryDB 1.0 readers.
+    /// </summary>
+    public bool KeyDigests { get; set; } = true;
+
     readonly MemoryArena arena = new();
     readonly List<TableBuilder> tableBuilders = [];
     FilterOptions? filterOptions;
@@ -175,8 +184,9 @@ public class DatabaseBuilder : IDisposable
         }
         header.MajorVersion = 1;
         // 1.1: B+Tree nodes may carry per-entry key digest arrays (flagged per page in
-        // the node header's kind field). 1.0 readers cannot parse such pages.
-        header.MinorVersion = 1;
+        // the node header's kind field). 1.0 readers cannot parse such pages, so files
+        // built with KeyDigests disabled stay marked (and byte-compatible) as 1.0.
+        header.MinorVersion = (byte)(KeyDigests ? 1 : 0);
         header.PageFilterCount = (ushort)(filterOptions?.Filters.Count ?? 0);
         header.PageSize = PageSize;
         header.TableCount = (ushort)tableBuilders.Count;
@@ -209,6 +219,7 @@ public class DatabaseBuilder : IDisposable
                 tableBuilders[i].KeyValues,
                 filterOptions?.Filters,
                 indexDescriptorEndPositionsList[i],
+                KeyDigests,
                 cancellationToken);
         }
 

--- a/src/DryDB/DryDBCodec.Encode.cs
+++ b/src/DryDB/DryDBCodec.Encode.cs
@@ -148,6 +148,7 @@ static partial class DryDBCodec
         KeyValueList keyValues,
         IReadOnlyList<IPageFilter>? pageFilters,
         long[] indexDescriptorEndPositions,
+        bool keyDigests = true,
         CancellationToken cancellationToken = default)
     {
         // write primary tree
@@ -156,6 +157,7 @@ static partial class DryDBCodec
             pageSize,
             keyValues,
             pageFilters,
+            keyDigests,
             cancellationToken);
 
         // write primary tree root position
@@ -181,7 +183,7 @@ static partial class DryDBCodec
             }
 
             // write secondary key tree
-            var secondaryKeyResult = await TreeBuilder.BuildToAsync(stream, pageSize, secondaryKeyValues, pageFilters, cancellationToken);
+            var secondaryKeyResult = await TreeBuilder.BuildToAsync(stream, pageSize, secondaryKeyValues, pageFilters, keyDigests, cancellationToken);
 
             // write secondary tree root position
             Span<byte> positionBuffer2 = stackalloc byte[sizeof(long)];

--- a/src/DryDB/IKeyEncoding.cs
+++ b/src/DryDB/IKeyEncoding.cs
@@ -16,6 +16,22 @@ public interface IKeyEncoding : IComparer<ReadOnlyMemory<byte>>
 
     int Compare(ReadOnlySpan<byte> a, ReadOnlySpan<byte> b);
 
+    /// <summary>
+    /// Whether <see cref="GetKeyDigest"/> yields an order-preserving digest for this
+    /// encoding. When true, the database builder stores a contiguous array of digests
+    /// in each B+Tree node and searches probe that array instead of dereferencing the
+    /// variable-length keys — one cache line covers eight probes.
+    /// </summary>
+    bool SupportsKeyDigest => false;
+
+    /// <summary>
+    /// A 64-bit order-preserving digest of the encoded key:
+    /// digest(a) &lt; digest(b) implies Compare(a, b) &lt; 0, and Compare(a, b) &lt; 0
+    /// implies digest(a) &lt;= digest(b). Equal digests are ambiguous and the caller
+    /// falls back to <see cref="Compare(ReadOnlySpan{byte}, ReadOnlySpan{byte})"/>.
+    /// </summary>
+    ulong GetKeyDigest(ReadOnlySpan<byte> key) => 0;
+
     int GetMaxEncodedByteCount<TKey>(TKey key)
         where TKey : IComparable<TKey>;
 
@@ -94,6 +110,19 @@ public sealed class Int64LittleEndianEncoding : IKeyEncoding
         var na = Unsafe.ReadUnaligned<long>(ref MemoryMarshal.GetReference(a));
         var nb = Unsafe.ReadUnaligned<long>(ref MemoryMarshal.GetReference(b));
         return (na > nb ? 1 : 0) - (na < nb ? 1 : 0);
+    }
+
+    public bool SupportsKeyDigest => true;
+
+    /// <summary>
+    /// Exact digest: flipping the sign bit maps the signed comparison onto the
+    /// unsigned digest comparison, so equal digests mean equal keys.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public ulong GetKeyDigest(ReadOnlySpan<byte> key)
+    {
+        var value = Unsafe.ReadUnaligned<long>(ref MemoryMarshal.GetReference(key));
+        return (ulong)value ^ 0x8000_0000_0000_0000UL;
     }
 
     public int GetMaxEncodedByteCount<TKey>(TKey key)
@@ -190,6 +219,24 @@ public sealed class AsciiOrdinalEncoding : IKeyEncoding
     public int Compare(ReadOnlySpan<byte> a, ReadOnlySpan<byte> b)
     {
         return a.SequenceCompareTo(b);
+    }
+
+    public bool SupportsKeyDigest => true;
+
+    /// <summary>
+    /// The first eight key bytes packed big-endian (zero padded), which preserves the
+    /// byte-lexicographic order. Keys sharing an 8-byte prefix collide and fall back
+    /// to the full comparison.
+    /// </summary>
+    public ulong GetKeyDigest(ReadOnlySpan<byte> key)
+    {
+        var length = Math.Min(key.Length, sizeof(ulong));
+        var digest = 0UL;
+        for (var i = 0; i < length; i++)
+        {
+            digest |= (ulong)key[i] << (56 - i * 8);
+        }
+        return digest;
     }
 
     public int GetMaxEncodedByteCount<TKey>(TKey key) where TKey : IComparable<TKey>

--- a/src/DryDB/Internal/DuplicateKeyEncoding.cs
+++ b/src/DryDB/Internal/DuplicateKeyEncoding.cs
@@ -15,6 +15,13 @@ class DuplicateKeyEncoding(IKeyEncoding sourceEncoding) : IKeyEncoding
     public int Compare(ReadOnlyMemory<byte> a, ReadOnlyMemory<byte> b) =>
         Compare(a.Span, b.Span);
 
+    public bool SupportsKeyDigest => sourceEncoding.SupportsKeyDigest;
+
+    // The source key dominates the (source, rid) order, so its digest is a valid
+    // coarse digest for the composite key; rid ties collide and fall back.
+    public ulong GetKeyDigest(ReadOnlySpan<byte> key) =>
+        sourceEncoding.GetKeyDigest(key[..^sizeof(int)]);
+
     public int Compare(ReadOnlySpan<byte> a, ReadOnlySpan<byte> b)
     {
         var aOriginal = a[..^sizeof(int)];

--- a/src/DryDB/RangeIterator.cs
+++ b/src/DryDB/RangeIterator.cs
@@ -26,12 +26,12 @@ public class RangeIterator :
         get
         {
             var header = NodeHeader.Parse(currentPage!.Memory.Span);
-            if (header.Kind != NodeKind.Leaf)
+            if (header.NodeKind != NodeKind.Leaf)
             {
                 throw new InvalidOperationException("Invalid node kind");
             }
 
-            var reader = new LeafNodeReader(currentPage.Memory.Span, header.EntryCount);
+            var reader = new LeafNodeReader(currentPage.Memory.Span, header.EntryCount, header.HasKeyDigests);
             reader.GetAt(currentEntryIndex, out var pageOffset, out var keyLength, out _);
             return currentPage.Memory.Slice(pageOffset, keyLength);
         }
@@ -45,11 +45,11 @@ public class RangeIterator :
             currentOverflowPage = null;
 
             var header = NodeHeader.Parse(currentPage!.Memory.Span);
-            if (header.Kind != NodeKind.Leaf)
+            if (header.NodeKind != NodeKind.Leaf)
             {
                 throw new InvalidOperationException("Invalid node kind");
             }
-            var reader = new LeafNodeReader(currentPage.Memory.Span, header.EntryCount);
+            var reader = new LeafNodeReader(currentPage.Memory.Span, header.EntryCount, header.HasKeyDigests);
             reader.GetAt(currentEntryIndex, out var pageOffset, out var keyLength, out var valueLength);
 
             if (LeafNodeReader.IsOverflow(valueLength))
@@ -200,7 +200,7 @@ public class RangeIterator :
             currentPage = pageCache.GetOrLoad(header.RightSiblingPageNumber);
 
             header = currentPage.GetNodeHeader();
-            if (header.Kind != NodeKind.Leaf)
+            if (header.NodeKind != NodeKind.Leaf)
             {
                 throw new InvalidOperationException("Invalid node kind");
             }
@@ -249,7 +249,7 @@ public class RangeIterator :
             currentPage = pageCache.GetOrLoad(header.LeftSiblingPageNumber);
 
             var leftHeader = currentPage.GetNodeHeader();
-            if (leftHeader.Kind != NodeKind.Leaf)
+            if (leftHeader.NodeKind != NodeKind.Leaf)
             {
                 throw new InvalidOperationException("Invalid node kind");
             }
@@ -305,7 +305,7 @@ public class RangeIterator :
             currentPage = await pageCache.GetOrLoadAsync(header.RightSiblingPageNumber).ConfigureAwait(false);
 
             header = currentPage.GetNodeHeader();
-            if (header.Kind != NodeKind.Leaf)
+            if (header.NodeKind != NodeKind.Leaf)
             {
                 throw new InvalidOperationException("Invalid node kind");
             }
@@ -354,7 +354,7 @@ public class RangeIterator :
             currentPage = await pageCache.GetOrLoadAsync(header.LeftSiblingPageNumber).ConfigureAwait(false);
 
             var leftHeader = currentPage.GetNodeHeader();
-            if (leftHeader.Kind != NodeKind.Leaf)
+            if (leftHeader.NodeKind != NodeKind.Leaf)
             {
                 throw new InvalidOperationException("Invalid node kind");
             }

--- a/tests/DryDB.Tests/DatabaseBuilderTest.cs
+++ b/tests/DryDB.Tests/DatabaseBuilderTest.cs
@@ -37,7 +37,7 @@ public class DatabaseBuilderTest
         var treeBytes = memoryStream.ToArray().AsSpan((int)primaryKeyDescriptor.RootPageNumber.Value);
         var nodeHeader = NodeHeader.Parse(treeBytes);
         Assert.That(nodeHeader.EntryCount, Is.EqualTo(3));
-        Assert.That(nodeHeader.Kind, Is.EqualTo(NodeKind.Leaf));
+        Assert.That(nodeHeader.NodeKind, Is.EqualTo(NodeKind.Leaf));
         Assert.That(nodeHeader.EntryCount, Is.EqualTo(3));
         Assert.That(nodeHeader.LeftSiblingPageNumber.IsEmpty, Is.True);
         Assert.That(nodeHeader.RightSiblingPageNumber.IsEmpty, Is.True);

--- a/tests/DryDB.Tests/ReadOnlyTableTest.cs
+++ b/tests/DryDB.Tests/ReadOnlyTableTest.cs
@@ -90,6 +90,38 @@ public class ReadOnlyTableTest
     }
 
     [Test]
+    public async Task Get_KeyDigestsDisabled()
+    {
+        // KeyDigests = false produces the 1.0 page layout; readers detect the absence
+        // of the per-page flag and use the plain search path.
+        var table = await TestHelper.BuildTableAsync(
+            KeyEncoding.Ascii,
+            databaseConfigure: builder =>
+            {
+                builder.PageSize = 128;
+                builder.KeyDigests = false;
+            },
+            tableConfigure: builder =>
+            {
+                for (var i = 0; i < 300; i++)
+                {
+                    builder.Append(
+                        Encoding.ASCII.GetBytes($"key{i:D5}"),
+                        Encoding.ASCII.GetBytes($"value{i:D5}"));
+                }
+            });
+
+        using var result1 = table.Get("key00123"u8);
+        Assert.That(result1.HasValue, Is.True);
+        Assert.That(result1.Value.Span.SequenceEqual("value00123"u8), Is.True);
+
+        using var rangeResult = table.GetRange("key00100"u8, "key00110"u8);
+        Assert.That(rangeResult.Count, Is.EqualTo(11));
+
+        Assert.That(table.CountRange("key00100"u8, "key00199"u8), Is.EqualTo(100));
+    }
+
+    [Test]
     public async Task Get_KeysSharingDigestPrefix()
     {
         // All keys share their first 8 bytes, so every key digest collides and the

--- a/tests/DryDB.Tests/ReadOnlyTableTest.cs
+++ b/tests/DryDB.Tests/ReadOnlyTableTest.cs
@@ -90,6 +90,39 @@ public class ReadOnlyTableTest
     }
 
     [Test]
+    public async Task Get_KeysSharingDigestPrefix()
+    {
+        // All keys share their first 8 bytes, so every key digest collides and the
+        // search must fall back to full key comparisons.
+        var table = await TestHelper.BuildTableAsync(
+            KeyEncoding.Ascii,
+            databaseConfigure: builder => builder.PageSize = 256,
+            tableConfigure: builder =>
+            {
+                for (var i = 0; i < 300; i++)
+                {
+                    builder.Append(
+                        Encoding.ASCII.GetBytes($"commonprefix{i:D5}"),
+                        Encoding.ASCII.GetBytes($"value{i:D5}"));
+                }
+            });
+
+        using var result1 = table.Get("commonprefix00123"u8);
+        Assert.That(result1.HasValue, Is.True);
+        Assert.That(result1.Value.Span.SequenceEqual("value00123"u8), Is.True);
+
+        using var result2 = table.Get("commonprefix99999"u8);
+        Assert.That(result2.HasValue, Is.False);
+
+        using var rangeResult = table.GetRange("commonprefix00100"u8, "commonprefix00110"u8);
+        Assert.That(rangeResult.Count, Is.EqualTo(11));
+
+        Assert.That(
+            table.CountRange("commonprefix00100"u8, "commonprefix00199"u8),
+            Is.EqualTo(100));
+    }
+
+    [Test]
     public async Task Get_TypedKey()
     {
         var table = await TestHelper.BuildTableAsync(

--- a/tests/DryDB.Tests/TreeBuilderTest.cs
+++ b/tests/DryDB.Tests/TreeBuilderTest.cs
@@ -29,7 +29,7 @@ public class TreeBuilderTest
         var header = NodeHeader.Parse(result);
 
         Assert.That(buildResult.RootPageNumber.Value, Is.EqualTo(0));
-        Assert.That(header.Kind, Is.EqualTo(NodeKind.Leaf));
+        Assert.That(header.NodeKind, Is.EqualTo(NodeKind.Leaf));
     }
 
     [Test]
@@ -46,7 +46,6 @@ public class TreeBuilderTest
             { "key07"u8.ToArray(), "value07"u8.ToArray() },
             { "key08"u8.ToArray(), "value08"u8.ToArray() },
             { "key09"u8.ToArray(), "value09"u8.ToArray() },
-            { "key10"u8.ToArray(), "value10"u8.ToArray() },
         };
 
         var memoryStream = new MemoryStream();
@@ -58,19 +57,20 @@ public class TreeBuilderTest
         var result = memoryStream.ToArray();
 
         var header = NodeHeader.Parse(result.AsSpan((int)buildResult.RootPageNumber.Value));
-        Assert.That(header.Kind, Is.EqualTo(NodeKind.Internal));
-        Assert.That(header.EntryCount, Is.EqualTo(2));
+        Assert.That(header.NodeKind, Is.EqualTo(NodeKind.Internal));
+        Assert.That(header.EntryCount, Is.EqualTo(3));
 
-        var internalNode = new InternalNodeReader(result.AsSpan((int)buildResult.RootPageNumber.Value), header.EntryCount);
+        var internalNode = new InternalNodeReader(
+            result.AsSpan((int)buildResult.RootPageNumber.Value), header.EntryCount, header.HasKeyDigests);
         internalNode.GetAt(0, out var internalKey1, out var childPosition1);
         internalNode.GetAt(1, out var internalKey2, out var childPosition2);
 
         Assert.That(internalKey1.SequenceEqual("key01"u8), Is.True);
-        Assert.That(internalKey2.SequenceEqual("key06"u8), Is.True);
+        Assert.That(internalKey2.SequenceEqual("key04"u8), Is.True);
 
         header = NodeHeader.Parse(result.AsSpan((int)childPosition1.Value));
-        Assert.That(header.Kind, Is.EqualTo(NodeKind.Leaf));
-        Assert.That(header.EntryCount, Is.EqualTo(5));
+        Assert.That(header.NodeKind, Is.EqualTo(NodeKind.Leaf));
+        Assert.That(header.EntryCount, Is.EqualTo(3));
         Assert.That(header.LeftSiblingPageNumber.IsEmpty, Is.True);
         // Assert.That(header.RightSiblingPosition, Is.EqualTo());
 

--- a/tests/DryDB.Tests/TreeWalkerTest.cs
+++ b/tests/DryDB.Tests/TreeWalkerTest.cs
@@ -31,7 +31,7 @@ public class TreeWalkerTest
         Assert.That(result, Is.True);
 
         var nodeHeader = NodeHeader.Parse(page.Memory.Span);
-        var leafNode = new LeafNodeReader(page.Memory.Span, nodeHeader.EntryCount);
+        var leafNode = new LeafNodeReader(page.Memory.Span, nodeHeader.EntryCount, nodeHeader.HasKeyDigests);
 
         leafNode.GetAt(index, out var pageOffset, out var keyLength, out var valueLength);
         var key = page.Memory.Span.Slice(pageOffset, keyLength);
@@ -70,7 +70,7 @@ public class TreeWalkerTest
         Assert.That(result, Is.True);
 
         var header = NodeHeader.Parse(page.Memory.Span);
-        var leafNode = new LeafNodeReader(page.Memory.Span, header.EntryCount);
+        var leafNode = new LeafNodeReader(page.Memory.Span, header.EntryCount, header.HasKeyDigests);
 
         leafNode.GetAt(pos, out var pageOffset, out var keyLength, out var valueLength);
         var key = page.Memory.Span.Slice(pageOffset, keyLength);
@@ -109,7 +109,7 @@ public class TreeWalkerTest
         Assert.That(result, Is.True);
 
         var header = NodeHeader.Parse(page.Memory.Span);
-        var leafNode = new LeafNodeReader(page.Memory.Span, header.EntryCount);
+        var leafNode = new LeafNodeReader(page.Memory.Span, header.EntryCount, header.HasKeyDigests);
 
         leafNode.GetAt(pos, out var pageOffset, out var keyLength, out var valueLength);
         var key = page.Memory.Span.Slice(pageOffset, keyLength);


### PR DESCRIPTION
## Summary

B+Tree nodes now carry a contiguous array of 8-byte **order-preserving key digests**, and searches probe that array instead of dereferencing the variable-length keys scattered across the page. One cache line covers eight probes, and the per-probe two-step dependent load (meta → key) collapses to a single load.

| Case | Before | After | |
|---|---:|---:|---|
| Point lookup, 10k rows (fixed key) | 24.8 µs | **18.1 µs** | -27% |
| Point lookup, 10k rows (random keys) | 43.4 µs | **33.4 µs** | -23% |
| Point lookup, 1M rows (fixed key) | 59.7 µs | **53.9 µs** | -10% |
| Point lookup, 1M rows (random keys) | 88.2 µs | 87.7 µs | neutral |
| Range scan, 1M rows | 45.9 µs | 47.8 µs | neutral |

(1 op = 1000 queries. The 1M cases are DRAM-latency bound, where fewer touched lines and a ~20% larger page count cancel out; the win is in the CPU/cache-bound regime.)

## Digest definitions

`IKeyEncoding` gains `SupportsKeyDigest` / `GetKeyDigest` (default interface members, so custom encodings are unaffected):

- **Int64LittleEndian** — the value with its sign bit flipped: an exact total order, so searches never touch key bytes at all.
- **Ascii** — first 8 key bytes packed big-endian (zero-padded): byte-lexicographic order maps onto unsigned comparison; keys sharing an 8-byte prefix collide and fall back to the full comparison.
- **DuplicateKeyEncoding** (non-unique secondary indexes) — delegates to the source encoding's digest of the key without the rid suffix.
- **UUIDv7 / custom encodings** — no digest (`Guid.CompareTo` is not byte-lexicographic); their trees keep the plain layout automatically.

## Format & compatibility

- Page layout (digest pages): `[PageHeader][NodeHeader][digest u64 × N][meta × N][payload]`.
- The flag lives in the upper bits of the node header's kind field (`NodeFlags.HasKeyDigests`), **per page** — digest and plain trees coexist in one file, and 1.0 files remain fully readable.
- **`DatabaseBuilder.KeyDigests` (default `true`)** — disable to produce byte-identical 1.0 output (header stays MinorVersion 0) at the cost of the search speedup. File-size cost when enabled: +8 bytes/entry (~+27% for this benchmark's 13-byte values; proportionally less for larger values).
- Files built with digests are marked MinorVersion 1. Note: published 1.0 readers do not validate the version and cannot parse digest pages — worth a release-note callout.

## Also

- Fixed a latent bound-search bug (exists on main): `Search`/`SearchAsync` with LowerBound/UpperBound returned not-found when the bound was the first entry of the *next* leaf; they now continue to the right sibling. The new page layout shifted leaf boundaries and exposed this in existing range tests.
- New benchmark: `BigReadBenchmark` (1M rows, ~40 MB) covering the DRAM-bound regime.
- New tests: digest-collision fallback (keys sharing an 8-byte prefix) and the `KeyDigests = false` layout.

All 75 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)